### PR TITLE
Add caching for gameNode.board()

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -81,16 +81,20 @@ class GameNode(object):
         self.starting_comment = ""
         self.comment = ""
         self.variations = []
+        self.board_cached = None
 
     def board(self):
         """
         Gets a bitboard with the position of the node.
 
-        Its a copy, so modifying the board will not alter the game.
+        It's a copy, so modifying the board will not alter the game.
         """
-        board = self.parent.board()
-        board.push(self.move)
-        return board
+		
+        if not self.board_cached:
+            self.board_cached = self.parent.board()
+            self.board_cached.push(self.move)
+        
+        return copy.copy(self.board_cached)
 
     def san(self):
         """


### PR DESCRIPTION
I added caching for gameNode.board().

In my application, I am going through a lot of games in PGN format and simply extracting all positions as EPD, with the supplied moves.

It was very slow, and I found that's because for every position, all boards leading up to that position are being recursively rebuilt.

I added caching so that it remembers the board for subsequent use (in my case, that's for building the board for the next position). It shouldn't impact performance on applications that don't call the function, because it's only computed on first use. For my application, it's now O(n) instead of O(n^2) for a game of length n.

On a test input file with 780 games -
CPython -
Old - 3:37
New - 0:41

Pypy3 -
Old - 1:10
New - 0:30

Thanks!
Matthew
