### PR TITLE
Allow many moves to be listed in epds.

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1700,8 +1700,10 @@ class Board(object):
                                 except ValueError:
                                     if position is None:
                                         position = self.__class__(" ".join(parts + ["0", "1"]))
-
-                                    operations[opcode] = position.parse_san(operand)
+                                    moves = operand.split()
+                                    operations[opcode] = []
+                                    for move in moves:
+                                        operations[opcode].append(position.parse_san(move))
 
                         opcode = ""
                         operand = ""


### PR DESCRIPTION
The EPD file format allows many moves to be listed in the 'bm' (best moves) or other move lists.  This commit resolves that.

There is another bug in the EPD format which prevents the 'pv' line from working.  This is natually a list of moves to be played, and both versions fail to parse this.

A crazy EPD to test this with is this:

2Q4Q/R4Q2/3Q4/1Q4Q1/4Q3/2Q4K/Q4RNp/3B1Nkq w - - acd 5; acs 0; bm Ba4 Bb3 Bc2 Be2 Bf3 Bg4 Bh5 Kg3 Kg4 Kh4 Nd2 Ne1+ Nf4+ Nfe3 Ng3 Nge3+ Nh4+ Nxh2 Q3c4 Q3c5 Q3c6 Q3c7 Q8c4 Q8c5 Q8c6 Q8c7 Qaa1 Qaa3 Qaa4 Qaa5 Qaa6 Qab1 Qab2 Qab3 Qac2 Qac4 Qad2 Qad5 Qae2 Qae6 Qba4 Qba5 Qba6 Qbb1 Qbb2 Qbb3 Qbb4 Qbb6 Qbb7 Qbb8 Qbc4 Qbc5 Qbc6 Qbd3 Qbd5 Qbd7 Qbe2 Qbe5 Qbe8 Qbf5 Qca1 Qca3 Qca5 Qca6 Qca8 Qcb2 Qcb3 Qcb4 Qcb7 Qcb8 Qcc1 Qcc2 Qcd2 Qcd3 Qcd4 Qcd7 Qcd8 Qce1 Qce3 Qce5 Qce6 Qce8 Qcf3 Qcf5 Qcf6 Qcf8 Qcg3 Qcg4 Qcg7 Qcg8 Qda3 Qda6 Qdb4 Qdb6 Qdb8 Qdc5 Qdc6 Qdc7 Qdd2 Qdd3 Qdd4 Qdd5 Qdd7 Qdd8 Qde5 Qde6 Qde7 Qdf4 Qdf6 Qdf8 Qdg3 Qdg6 Qdh6 Qea4 Qea8 Qeb1 Qeb4 Qeb7 Qec2 Qec4 Qec6 Qed3 Qed4 Qed5 Qee1 Qee2 Qee3 Qee5 Qee6 Qee7 Qee8 Qef3 Qef4 Qef5 Qeg4 Qeg6 Qeh4 Qeh7 Qfb3 Qfb7 Qfc4 Qfc7 Qfd5 Qfd7 Qfe6 Qfe7 Qfe8 Qff3 Qff4 Qff5 Qff6 Qff8 Qfg6 Qfg7 Qfg8 Qfh5 Qfh7 Qgc1 Qgc5 Qgd2 Qgd5 Qgd8 Qge3 Qge5 Qge7 Qgf4 Qgf5 Qgf6 Qgg3 Qgg4 Qgg6 Qgg7 Qgg8 Qgh4 Qgh5 Qgh6 Qhd4 Qhd8 Qhe5 Qhe8 Qhf6 Qhf8 Qhg7 Qhg8 Qhh4 Qhh5 Qhh6 Qhh7 Ra3 Ra4 Ra5 Ra6 Ra8 Rb2 Rb7 Rc2 Rc7 Rd2 Rd7 Re2 Re7 Rf3 Rf4 Rf5 Rf6; ce 32764; dm 2; pm Nge3+; pv Nge3+ Qg2+ Qgxg2#;

This version will now parse the 'bm' tag, but still not the 'pv' tag.