### PR TITLE
Enable Python 2.6 compatibility.

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -23,10 +23,14 @@ __email__ = "niklas.fiekas@tu-clausthal.de"
 __version__ = "0.11.1"
 
 
-import collections
 import copy
 import re
+import sys
 
+if sys.version_info<(2,7):
+    import backport_collections as collections
+else:
+    import collections
 
 COLORS = [WHITE, BLACK] = [True, False]
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -17,10 +17,14 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import chess
-import collections
 import itertools
 import re
+import sys
 
+if sys.version_info<(2,7):
+    import backport_collections as collections
+else:
+    import collections
 
 NAG_NULL = 0
 

--- a/chess/polyglot.py
+++ b/chess/polyglot.py
@@ -72,10 +72,9 @@ class MemoryMappedReader(object):
 
         try:
             self.mmap = mmap.mmap(self.fd, 0, access=mmap.ACCESS_READ)
-        except Exception as e:
-            if type(e)==ValueError or (type(e)==mmap.error and e.errno==errno.EINVAL):
+        except (ValueError,mmap.error):
             # Can not memory map empty opening books.
-                self.mmap = None
+            self.mmap = None
 
     def __enter__(self):
         return self

--- a/chess/polyglot.py
+++ b/chess/polyglot.py
@@ -17,12 +17,19 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import chess
-import collections
 import struct
 import os
 import mmap
 import random
 import itertools
+import chess
+import errno
+import sys
+
+if sys.version_info<(2,7):
+    import backport_collections as collections
+else:
+    import collections
 
 
 ENTRY_STRUCT = struct.Struct(">QHHI")
@@ -65,9 +72,10 @@ class MemoryMappedReader(object):
 
         try:
             self.mmap = mmap.mmap(self.fd, 0, access=mmap.ACCESS_READ)
-        except ValueError:
+        except Exception as e:
+            if type(e)==ValueError or (type(e)==mmap.error and e.errno==errno.EINVAL):
             # Can not memory map empty opening books.
-            self.mmap = None
+                self.mmap = None
 
     def __enter__(self):
         return self

--- a/chess/uci.py
+++ b/chess/uci.py
@@ -17,12 +17,18 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import chess
-import collections
 import signal
 import subprocess
 import logging
 import threading
 import concurrent.futures
+import sys
+
+if sys.version_info<(2,7):
+    import backport_collections as collections
+else:
+    import collections
+
 
 try:
     import queue

--- a/test.py
+++ b/test.py
@@ -23,13 +23,19 @@ import chess.pgn
 import chess.uci
 import chess.syzygy
 import chess.gaviota
-import collections
 import os.path
 import textwrap
 import sys
 import time
 import unittest
 import logging
+
+if sys.version_info<(2,7):
+    import backport_collections as collections
+    import unittest2 as unittest
+else:
+    import collections
+    import unittest
 
 try:
     from StringIO import StringIO


### PR DESCRIPTION
In case the Python version is < 2.7 this patch enables the use 

backport_collections
unittest2

Both are available on pip.

On Python 2.6 mmap throws a different type of error. With this patch this error is correctly caught.

With these changes the test suite passes without errors (some tests are skipped but this is also true on my Python 2.7 system).

