### PR TITLE
Fix case that breaks when loading some PGN's, since accessing game.board() raises ValueError.

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -790,7 +790,11 @@ def read_game(handle, Visitor=GameModelCreator):
         line = handle.readline()
 
     # Movetext parser state.
-    board_stack = collections.deque([dummy_game.board()])
+    try:
+        board_stack = collections.deque([dummy_game.board()])
+    except ValueError as error:
+        visitor.handle_error(error)
+        board_stack = collections.deque([chess.Board()])
 
     # Parse movetext.
     while line:


### PR DESCRIPTION
Fix case that breaks when loading some PGN's, since accessing game.board() raises ValueError.