### PR TITLE
replaces copied functions with internal functions in engine module

### DIFF
--- a/chess/uci.py
+++ b/chess/uci.py
@@ -23,6 +23,8 @@ from chess.engine import PopenProcess
 from chess.engine import SpurProcess
 from chess.engine import LOGGER
 from chess.engine import FUTURE_POLL_TIMEOUT
+from chess.engine import _popen_engine
+from chess.engine import _spur_spawn_engine
 
 import chess
 
@@ -1179,24 +1181,7 @@ def popen_engine(command, engine_cls=Engine, setpgrp=False, _popen_lock=threadin
         stop signals (such as keyboards interrupts) from propagating from the
         parent process. Defaults to ``False``.
     """
-    engine = engine_cls()
-
-    popen_args = {}
-    if setpgrp:
-        try:
-            # Windows
-            popen_args["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
-        except AttributeError:
-            # Unix
-            popen_args["preexec_fn"] = os.setpgrp
-    popen_args.update(kwargs)
-
-    # Work around possible race condition in Python 2 subprocess module,
-    # that can occur when concurrently opening processes.
-    with _popen_lock:
-        PopenProcess(engine, command, **popen_args)
-
-    return engine
+    return _popen_engine(command, engine_cls, setpgrp, _popen_lock, **kwargs)
 
 
 def spur_spawn_engine(shell, command, engine_cls=Engine):
@@ -1210,6 +1195,4 @@ def spur_spawn_engine(shell, command, engine_cls=Engine):
 
     .. _Spur: https://pypi.python.org/pypi/spur
     """
-    engine = engine_cls()
-    SpurProcess(engine, shell, command)
-    return engine
+    return _spur_spawn_engine(shell, command, engine_cls)


### PR DESCRIPTION
Two functions were duplicated in the xboard and uci modules. This pulls the functions into engine.py and puts a wrapper in its place. I couldn't just move the function into engine.py because of the default argument for engine_cls.