### PR TITLE
Improve class Arrow in chess.svg

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -72,7 +72,7 @@ DEFAULT_STYLE = """\
 
 class Arrow(collections.namedtuple("Arrow", ["tail", "head"])):
     """Details of an arrow to be drawn."""
-    pass
+    __slots__ = ()
 
 
 def _svg(viewbox, size):


### PR DESCRIPTION
A subclass of `collections.namedtuple` must implement the `__slots__`
attribute and, in this case, an empty tuple must be assigned to it.