### PR TITLE
Beautify `DEFAULT_STYLE` constant

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -63,11 +63,7 @@ DEFAULT_COLORS = {
     "square light lastmove": "#cdd16a",
 }
 
-DEFAULT_STYLE = """\
-.check {
-  fill: url(#check_gradient);
-}
-"""
+DEFAULT_STYLE = ".check {fill: url(#check_gradient);}"
 
 
 class Arrow(collections.namedtuple("Arrow", "tail head")):


### PR DESCRIPTION
Since this is a constant and code will (probably) never be added to it, I guess we can put this just on one line and get rid of those triple quotes, the ugly backslash, and make the overall code in `chess.svg` a little bit cleaner.