### PR TITLE
Some small tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,7 @@ Features
 
 * Supports Python 2.6+, Python 3.3+ and PyPy.
 
-* IPython notebook integration.
+* Jupyter Notebook integration.
   `SVG rendering docs <https://python-chess.readthedocs.io/en/latest/svg.html>`_.
 
   .. code:: python

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -65,7 +65,7 @@ DEFAULT_COLORS = {
 
 DEFAULT_STYLE = """
 .check {
-  fill: url(#check_gradient);
+    fill: url(#check_gradient);
 }
 """
 
@@ -134,8 +134,8 @@ def board(board=None, squares=None, flipped=False, coordinates=True, lastmove=No
         ``[chess.svg.Arrow(chess.E2, chess.E4)]`` or a list of tuples like
         ``[(chess.E2, chess.E4)]``. An arrow from a square pointing to the same
         square is drawn as a circle, like ``[(chess.E2, chess.E2)]``.
-    :param size: The size of the image in pixels (e.g. ``400`` for a 400 by 400
-        board) or ``None`` (the default) for no size limit.
+    :param size: The size of the image in pixels (e.g., ``400`` for a 400 by
+        400 board) or ``None`` (the default) for no size limit.
     :param style: A CSS stylesheet to include in the SVG image.
 
     >>> import chess


### PR DESCRIPTION
In README.rst, `IPython notebook` is fixed to `Jupyter Notebook`,
because `IPython Notebook` is deprecated and will be gone in the future,
also capitalize the word `Notebook` because that's part of the official
name.

In `chess.svg`, some small tweaks are made.