### PR TITLE
Update svg.rst

### DIFF
--- a/docs/svg.rst
+++ b/docs/svg.rst
@@ -2,7 +2,7 @@ SVG rendering
 =============
 
 The :mod:`chess.svg` module renders SVG images (mostly for IPython/Jupyter
-notebook integration). The piece images by
+Notebook integration). The piece images by
 `Colin M.L. Burnett <https://en.wikipedia.org/wiki/User:Cburnett>`_ are triple
 licensed under the GFDL, BSD and GPL.
 


### PR DESCRIPTION
The word "notebook" is "Notebook" (capitalized) when refering to the IPython/Jupyter Notebook web application, so I fixed that.