### PR TITLE
Update docs/svg.rst

### DIFF
--- a/docs/svg.rst
+++ b/docs/svg.rst
@@ -2,7 +2,7 @@ SVG rendering
 =============
 
 The :mod:`chess.svg` module renders SVG images (mostly for IPython/Jupyter
-notebook integration). The piece images by
+Notebook integration). The piece images by
 `Colin M.L. Burnett <https://en.wikipedia.org/wiki/User:Cburnett>`_ are triple
 licensed under the GFDL, BSD and GPL.
 


### PR DESCRIPTION
I don't know why the build on Travis CI failed only for Python 3.6, so I'll do another pull request.