### PR TITLE
Code example fix in chess/svg.py

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -102,7 +102,7 @@ def piece(piece, size=None):
     >>> import chess
     >>> import chess.svg
     >>>
-    >>> from IPython.core.display import SVG
+    >>> from IPython.display import SVG
     >>>
     >>> SVG(chess.svg.piece(chess.Piece.from_symbol("R")))  # doctest: +SKIP
 


### PR DESCRIPTION
The `core` is not needed when calling the `SVG` function. `from IPython.display import SVG` is good enough.