### PR TITLE
Fix the chess/svg.py code examples

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -102,7 +102,7 @@ def piece(piece, size=None):
     >>> import chess
     >>> import chess.svg
     >>>
-    >>> from IPython.core.display import SVG
+    >>> from IPython.display import SVG
     >>>
     >>> SVG(chess.svg.piece(chess.Piece.from_symbol("R")))  # doctest: +SKIP
 
@@ -135,7 +135,7 @@ def board(board=None, squares=None, flipped=False, coordinates=True, lastmove=No
     >>> import chess
     >>> import chess.svg
     >>>
-    >>> from IPython.core.display import SVG
+    >>> from IPython.display import SVG
     >>>
     >>> board = chess.Board("8/8/8/8/4N3/8/8/8 w - - 0 1")
     >>> squares = board.attacks(chess.E4)


### PR DESCRIPTION
The `core` is not needed when calling the `SVG` function. `from IPython.display import SVG` is good enough.