### PR TITLE
Added offer_draw() API and DrawHandler

### DIFF
--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -296,7 +296,7 @@ class Engine(object):
         self.author = None
         self.features = FeatureMap()
         self.pong = threading.Event()
-        self.ping_num = None
+        self.ping_num = 123
         self.pong_received = threading.Condition()
         self.auto_force = False
         self.in_force = False
@@ -536,7 +536,6 @@ class Engine(object):
         def command():
             with self.semaphore:
                 with self.pong_received:
-                    self.ping_num = random.randint(1, 100)
                     self.send_line("ping " + str(self.ping_num))
                     self.pong_received.wait()
 

--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -43,7 +43,7 @@ class DrawHandler(object):
     one during an offer during it's calculations. A draw handler can be used to
     send, or react to, this information.
 
-    >>> # Register a standard post handler.
+    >>> # Register a standard draw handler.
     >>> draw_handler = chess.xboard.DrawHandler()
     >>> engine.draw_handler = draw_handler
 
@@ -66,9 +66,9 @@ class DrawHandler(object):
     you would usually subclass the *DrawHandler* class:
 
     >>> class MyHandler(chess.xboard.DrawHandler):
-    ...     def draw_offer(self):
-    ...         # Called whenever a complete *post* line has been processed.
-    ...         super(MyHandler, self).draw_offer()
+    ...     def offer_draw(self):
+    ...         # Called whenever `offer draw` has been processed.
+    ...         super(MyHandler, self).offer_draw()
     ...         print(self.pending_offer)
     """
     def __init__(self):


### PR DESCRIPTION
So I just wanted to put this here for review. I will of course add formal tests soon(with MockProcess probably) but for now I have used a modified test engine to give `offer draw` at appropriate times to test the sample script (plus few variations for each case). The cases tested were:
1. Engine offers draw during it's turn (engine gives `offer draw` after every pv post)
2. Engine offers draw during opponent's turn (engine gives `offer draw` after `move xyz`)
3. Human offers draw during engine's turn (engine gives `offer draw` after receiving `offer draw`)

This is the way I imagined a user would handle it. Please share your thoughts.
The script was:

```
import chess.xboard
import time
import logging

logging.basicConfig(level=logging.DEBUG)

class MyPostHandler(chess.xboard.PostHandler):
    def post_info(self):
        print(self.post)
        super(MyPostHandler, self).post_info()

post_handler = MyPostHandler()
draw_handler = chess.xboard.DrawHandler()

engine = chess.xboard.popen_engine("./wyldchess")
engine.post_handlers.append(post_handler)
engine.draw_handler = draw_handler

engine.xboard()
engine.st(10)
engine.go(async_callback=True)

# To test 3. just send engine.offer_draw() and then check engine.end_result as follows:
"""
time.sleep(5)
engine.offer_draw()
if engine.end_result == chess.xboard.DRAW:
    print("GOT RESULT: " + str(engine.end_result))
"""

# Value greater than 10 tests 2.
# Value less than 10 tests 1.
time.sleep(11)
if draw_handler.pending_offer:
    print("GOT DRAW OFFER")
    engine._end_game(chess.xboard.DRAW) # Replace with engine.result() once result() function added
print("GOT RESULT: " + str(engine.end_result))

print("DONE!")
```