### PR TITLE
Changed 'offer_draw' API to 'draw' as per the spec

### DIFF
--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -544,7 +544,7 @@ class Engine(object):
 
         return self._queue_command(command, async_callback)
 
-    def offer_draw(self, async_callback=None):
+    def draw(self, async_callback=None):
         """
         Command used to offer the engine a draw.
 
@@ -556,7 +556,7 @@ class Engine(object):
         self._assert_supports_feature("draw")
         if self.draw_handler:
             self.draw_handler.offer_draw()
-            command = self.command("offer draw")
+            command = self.command("draw")
             return self._queue_command(command, async_callback)
 
     def pondering(self, ponder, async_callback=None):

--- a/test.py
+++ b/test.py
@@ -2482,9 +2482,9 @@ class XboardEngineTestCase(unittest.TestCase):
         self.mock.expect("go")
         self.engine.go(async_callback=True)
 
-        self.mock.expect("offer draw", ("offer draw", ))
+        self.mock.expect("draw", ("offer draw", ))
         self.mock.expect("?")
-        self.engine.offer_draw()
+        self.engine.draw()
 
         time.sleep(0.01)
 


### PR DESCRIPTION
Stupid of me :p the API is actually `draw()` not `offer_draw()`, `offer draw` is only how the engine must reply.