### PR TITLE
Update xboard.py (small fix that was missed)

### DIFF
--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -157,7 +157,7 @@ class PostHandler(object):
         self.post["pv"] = {}
 
     def depth(self, depth):
-        """Receives the depth in plies."""
+        """Receives the search depth in plies."""
         self.post["depth"] = depth
 
     def score(self, score):


### PR DESCRIPTION
I've noticed that the `xboard` module documents its `chess.xboard.PostHandler.depth` method as `Receives the depth in plies.` whereas the `uci` module documents its own `depth` method as `Receives the search depth in plies.` (taking into account that my `uci` module patch will get merged). Anyway, this fix will unite the documentation of those two same-named methods from different modules.