### PR TITLE
Fix handling multiple features in on line

### DIFF
--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -347,13 +347,11 @@ class Engine(object):
             raise EngineStateException("Engine produced an error: {}".format(err_msg))
 
         command_and_args = buf.split()
-        if not command_and_args:
+        if command_and_args[0] == "#" or not command_and_args:
             return
 
         if len(command_and_args) == 1:
-            if command_and_args[0] == "#":
-                pass
-            elif command_and_args[0] == "resign":
+            if command_and_args[0] == "resign":
                 return self._resign()
         elif len(command_and_args) == 2:
             if command_and_args[0] == "pong":

--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -19,6 +19,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import concurrent.futures
+import shlex
 import threading
 
 from chess.engine import EngineTerminatedException
@@ -397,9 +398,8 @@ class Engine(object):
         Does not conform to the CECP spec regarding `done` and instead reads all
         the features atomically.
         """
-        if features.startswith("option"):
-            features = features.replace("\"", "")
-            params = features.split("=")[1].split()
+        def _option(feature):
+            params = feature.split()
             name = params[0]
             type = params[1][1:]
             default = None
@@ -431,12 +431,13 @@ class Engine(object):
             self.features.set_option(option.name, option)
             return
 
-        features = features.split()
+        features = shlex.split(features)
         feature_map = [feature.split("=") for feature in features]
         for (key, value) in feature_map:
-            value = value.strip("\"")
             if key == "variant":
                 self.features.set_feature(key, value.split(","))
+            elif key == "option":
+                _option(value)
             else:
                 self.features.set_feature(key, value)
 


### PR DESCRIPTION
xboard protocol enables two from of feature command:
feature NAME=VALUE
feature NAME1=VALUE1 NAME2=VALUE2 ...

In latter case str.split() doesn't save values surrounded by double quotes. This patch fixes this.
It also handles the case where an option feature is not in the first feature in the feature list.