### PR TITLE
BaseBoard handles full FENs

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -841,6 +841,7 @@ class BaseBoard(object):
 
     def _set_board_fen(self, fen):
         # Ensure the FEN is valid.
+        fen = fen.split(' ', 1)[0]
         rows = fen.split("/")
         if len(rows) != 8:
             raise ValueError("expected 8 rows in position part of fen: {0}".format(repr(fen)))


### PR DESCRIPTION
BaseBoard._set_board_fen crashed when passed a full FEN, e.g. from Board.fen(), since it only used the position part. Now it drops the latter part and sets the BaseBoard as expected.