### PR TITLE
Drop support for Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,11 @@ language: python
 dist: trusty
 sudo: false
 python:
- - "2.7"
  - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
  - "3.7-dev"
- - "pypy"
  - "pypy3"
 matrix:
   include:

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ python-chess:
 Features
 --------
 
-* Supports Python 2.7, Python 3.3+ and PyPy.
+* Supports Python 3.3+ and PyPy3.
 
 * IPython/Jupyter Notebook integration.
   `SVG rendering docs <https://python-chess.readthedocs.io/en/latest/svg.html>`_.

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -351,7 +351,7 @@ class Piece(object):
         return hash(self.piece_type * (self.color + 1))
 
     def __repr__(self):
-        return "Piece.from_symbol('{0}')".format(self.symbol())
+        return "Piece.from_symbol('{}')".format(self.symbol())
 
     def __str__(self):
         return self.symbol()
@@ -445,7 +445,7 @@ class Move(object):
             return NotImplemented
 
     def __repr__(self):
-        return "Move.from_uci('{0}')".format(self.uci())
+        return "Move.from_uci('{}')".format(self.uci())
 
     def __str__(self):
         return self.uci()
@@ -480,7 +480,7 @@ class Move(object):
             promotion = PIECE_SYMBOLS.index(uci[4])
             return cls(SQUARE_NAMES.index(uci[0:2]), SQUARE_NAMES.index(uci[2:4]), promotion=promotion)
         else:
-            raise ValueError("expected uci string to be of length 4 or 5: {0}".format(repr(uci)))
+            raise ValueError("expected uci string to be of length 4 or 5: {}".format(repr(uci)))
 
     @classmethod
     def null(cls):
@@ -852,12 +852,12 @@ class BaseBoard(object):
         # Compability with set_fen().
         fen = fen.strip()
         if " " in fen:
-            raise ValueError("expected position part of fen, got multiple parts: {0}".format(repr(fen)))
+            raise ValueError("expected position part of fen, got multiple parts: {}".format(repr(fen)))
 
         # Ensure the FEN is valid.
         rows = fen.split("/")
         if len(rows) != 8:
-            raise ValueError("expected 8 rows in position part of fen: {0}".format(repr(fen)))
+            raise ValueError("expected 8 rows in position part of fen: {}".format(repr(fen)))
 
         # Validate each row.
         for row in rows:
@@ -868,13 +868,13 @@ class BaseBoard(object):
             for c in row:
                 if c in ["1", "2", "3", "4", "5", "6", "7", "8"]:
                     if previous_was_digit:
-                        raise ValueError("two subsequent digits in position part of fen: {0}".format(repr(fen)))
+                        raise ValueError("two subsequent digits in position part of fen: {}".format(repr(fen)))
                     field_sum += int(c)
                     previous_was_digit = True
                     previous_was_piece = False
                 elif c == "~":
                     if not previous_was_piece:
-                        raise ValueError("~ not after piece in position part of fen: {0}".format(repr(fen)))
+                        raise ValueError("~ not after piece in position part of fen: {}".format(repr(fen)))
                     previous_was_digit = False
                     previous_was_piece = False
                 elif c.lower() in ["p", "n", "b", "r", "q", "k"]:
@@ -882,10 +882,10 @@ class BaseBoard(object):
                     previous_was_digit = False
                     previous_was_piece = True
                 else:
-                    raise ValueError("invalid character in position part of fen: {0}".format(repr(fen)))
+                    raise ValueError("invalid character in position part of fen: {}".format(repr(fen)))
 
             if field_sum != 8:
-                raise ValueError("expected 8 columns per row in position part of fen: {0}".format(repr(fen)))
+                raise ValueError("expected 8 columns per row in position part of fen: {}".format(repr(fen)))
 
         # Clear the board.
         self._clear_board()
@@ -933,7 +933,7 @@ class BaseBoard(object):
 
     def _set_chess960_pos(self, sharnagl):
         if not 0 <= sharnagl <= 959:
-            raise ValueError("chess960 position index not 0 <= {0} <= 959".format(repr(sharnagl)))
+            raise ValueError("chess960 position index not 0 <= {} <= 959".format(repr(sharnagl)))
 
         # See http://www.russellcottrell.com/Chess/Chess960.htm for
         # a description of the algorithm.
@@ -1091,7 +1091,7 @@ class BaseBoard(object):
             return None
 
     def __repr__(self):
-        return "{0}('{1}')".format(type(self).__name__, self.board_fen())
+        return "{}('{}')".format(type(self).__name__, self.board_fen())
 
     def __str__(self):
         builder = []
@@ -2055,29 +2055,29 @@ class Board(BaseBoard):
         # Ensure there are six parts.
         parts = fen.split()
         if len(parts) != 6:
-            raise ValueError("fen string should consist of 6 parts: {0}".format(repr(fen)))
+            raise ValueError("fen string should consist of 6 parts: {}".format(repr(fen)))
 
         # Check that the turn part is valid.
         if not parts[1] in ["w", "b"]:
-            raise ValueError("expected 'w' or 'b' for turn part of fen: {0}".format(repr(fen)))
+            raise ValueError("expected 'w' or 'b' for turn part of fen: {}".format(repr(fen)))
 
         # Check that the castling part is valid.
         if not FEN_CASTLING_REGEX.match(parts[2]):
-            raise ValueError("invalid castling part in fen: {0}".format(repr(fen)))
+            raise ValueError("invalid castling part in fen: {}".format(repr(fen)))
 
         # Check that the en passant part is valid.
         if parts[3] != "-":
             if parts[3] not in SQUARE_NAMES:
-                raise ValueError("invalid en passant part in fen: {0}".format(repr(fen)))
+                raise ValueError("invalid en passant part in fen: {}".format(repr(fen)))
 
         # Check that the half-move part is valid.
         if int(parts[4]) < 0:
-            raise ValueError("half-move clock can not be negative: {0}".format(repr(fen)))
+            raise ValueError("half-move clock can not be negative: {}".format(repr(fen)))
 
         # Check that the full-move number part is valid.
         # 0 is allowed for compability, but later replaced with 1.
         if int(parts[5]) < 0:
-            raise ValueError("full-move number must be positive: {0}".format(repr(fen)))
+            raise ValueError("full-move number must be positive: {}".format(repr(fen)))
 
         # Validate the board part and set it.
         self._set_board_fen(parts[0])
@@ -2110,7 +2110,7 @@ class Board(BaseBoard):
             return
 
         if not FEN_CASTLING_REGEX.match(castling_fen):
-            raise ValueError("invalid castling fen: {0}".format(repr(castling_fen)))
+            raise ValueError("invalid castling fen: {}".format(repr(castling_fen)))
 
         self.castling_rights = BB_VOID
 
@@ -2394,7 +2394,7 @@ class Board(BaseBoard):
         # Split into 4 or 5 parts.
         parts = epd.strip().rstrip(";").split(None, 4)
         if len(parts) < 4:
-            raise ValueError("epd should consist of at least 4 parts: {0}".format(repr(epd)))
+            raise ValueError("epd should consist of at least 4 parts: {}".format(repr(epd)))
 
         # Parse ops.
         if len(parts) > 4:
@@ -2532,12 +2532,12 @@ class Board(BaseBoard):
 
         for move in variation:
             if not board.is_legal(move):
-                raise ValueError("illegal move {0} in position {1}".format(move, board.fen()))
+                raise ValueError("illegal move {} in position {}".format(move, board.fen()))
 
             if board.turn == WHITE:
-                san.append("{0}. {1}".format(board.fullmove_number, board.san(move)))
+                san.append("{}. {}".format(board.fullmove_number, board.san(move)))
             elif not san:
-                san.append("{0}...{1}".format(board.fullmove_number, board.san(move)))
+                san.append("{}...{}".format(board.fullmove_number, board.san(move)))
             else:
                 san.append(board.san(move))
 
@@ -2561,7 +2561,7 @@ class Board(BaseBoard):
             elif san in ["O-O-O", "O-O-O+", "O-O-O#"]:
                 return next(move for move in self.generate_castling_moves() if self.is_queenside_castling(move))
         except StopIteration:
-            raise ValueError("illegal san: {0} in {1}".format(repr(san), self.fen()))
+            raise ValueError("illegal san: {} in {}".format(repr(san), self.fen()))
 
         # Match normal moves.
         match = SAN_REGEX.match(san)
@@ -2570,7 +2570,7 @@ class Board(BaseBoard):
             if san in ["--", "Z0"]:
                 return Move.null()
 
-            raise ValueError("invalid san: {0}".format(repr(san)))
+            raise ValueError("invalid san: {}".format(repr(san)))
 
         # Get target square.
         to_square = SQUARE_NAMES.index(match.group(4))
@@ -2602,12 +2602,12 @@ class Board(BaseBoard):
                 continue
 
             if matched_move:
-                raise ValueError("ambiguous san: {0} in {1}".format(repr(san), self.fen()))
+                raise ValueError("ambiguous san: {} in {}".format(repr(san), self.fen()))
 
             matched_move = move
 
         if not matched_move:
-            raise ValueError("illegal san: {0} in {1}".format(repr(san), self.fen()))
+            raise ValueError("illegal san: {} in {}".format(repr(san), self.fen()))
 
         return matched_move
 
@@ -2658,7 +2658,7 @@ class Board(BaseBoard):
         move = self._from_chess960(self.chess960, move.from_square, move.to_square, move.promotion, move.drop)
 
         if not self.is_legal(move):
-            raise ValueError("illegal uci: {0} in {1}".format(repr(uci), self.fen()))
+            raise ValueError("illegal uci: {} in {}".format(repr(uci), self.fen()))
 
         return move
 
@@ -3169,9 +3169,9 @@ class Board(BaseBoard):
 
     def __repr__(self):
         if not self.chess960:
-            return "{0}('{1}')".format(type(self).__name__, self.fen())
+            return "{}('{}')".format(type(self).__name__, self.fen())
         else:
-            return "{0}('{1}', chess960=True)".format(type(self).__name__, self.fen())
+            return "{}('{}', chess960=True)".format(type(self).__name__, self.fen())
 
     def _repr_svg_(self):
         import chess.svg
@@ -3280,7 +3280,7 @@ class PseudoLegalMoveGenerator(object):
 
         sans = ", ".join(builder)
 
-        return "<PseudoLegalMoveGenerator at {0} ({1})>".format(hex(id(self)), sans)
+        return "<PseudoLegalMoveGenerator at {} ({})>".format(hex(id(self)), sans)
 
 
 class LegalMoveGenerator(object):
@@ -3305,7 +3305,7 @@ class LegalMoveGenerator(object):
 
     def __repr__(self):
         sans = ", ".join(self.board.san(move) for move in self)
-        return "<LegalMoveGenerator at {0} ({1})>".format(hex(id(self)), sans)
+        return "<LegalMoveGenerator at {} ({})>".format(hex(id(self)), sans)
 
 
 class SquareSet(object):

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -34,14 +34,14 @@ import re
 import itertools
 import struct
 import sys
-import warnings
 
 if sys.version_info < (3, ):
-    warnings.warn("You are using the master branch of python-chess with Python 2. "
-                  "Python 2 support will be dropped soon. Consider upgrading, "
-                  "or using the 0.23.x branch, which will be maintained until "
-                  "the end of 2018.",
-                  UserWarning)
+    raise ImportError(
+        """You are using python-chess on Python 2.
+
+Python 2 support has been dropped. Consider upgrading to Python 3, or using 
+the 0.23.x branch, which will be maintained until the end of 2018.
+""")
 
 COLORS = [WHITE, BLACK] = [True, False]
 COLOR_NAMES = ["black", "white"]

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2273,11 +2273,9 @@ class Board(BaseBoard):
         >>> board.epd(hmvc=board.halfmove_clock, fmvc=board.fullmove_number)
         'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - hmvc 0; fmvc 1;'
         """
-        epd = []
-
-        epd.append(self.board_fen(promoted=promoted))
-        epd.append("w" if self.turn == WHITE else "b")
-        epd.append(self.castling_shredder_fen() if shredder else self.castling_xfen())
+        epd = [self.board_fen(promoted=promoted),
+               "w" if self.turn == WHITE else "b",
+               self.castling_shredder_fen() if shredder else self.castling_xfen()]
 
         if en_passant == "fen":
             epd.append(SQUARE_NAMES[self.ep_square] if self.ep_square is not None else "-")

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -18,26 +18,12 @@
 
 import collections
 import logging
-import threading
 import os
-import sys
-import signal
 import platform
-
-
-try:
-    import queue  # Python 3
-except ImportError:
-    import Queue as queue  # Python 2
-
-if os.name == "posix" and sys.version_info[0] < 3:
-    try:
-        import subprocess32 as subprocess
-    except ImportError:
-        import subprocess
-else:
-    import subprocess
-
+import queue
+import signal
+import subprocess
+import threading
 
 FUTURE_POLL_TIMEOUT = 0.1 if platform.system() == "Windows" else 60
 

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -71,7 +71,7 @@ class MockProcess(object):
         self._expectations.append((expectation, responses))
 
     def assert_done(self):
-        assert not self._expectations, "pending expectations: {0}".format(self._expectations)
+        assert not self._expectations, "pending expectations: {}".format(self._expectations)
 
     def assert_terminated(self):
         self.assert_done()
@@ -93,9 +93,9 @@ class MockProcess(object):
     def send_line(self, string):
         assert self.is_alive()
 
-        assert self._expectations, "unexpected: {0}".format(string)
+        assert self._expectations, "unexpected: {}".format(string)
         expectation, responses = self._expectations.popleft()
-        assert expectation == string, "expected: {0}, got {1}".format(expectation, string)
+        assert expectation == string, "expected: {}, got {}".format(expectation, string)
 
         for response in responses:
             self._send_queue.put(response)
@@ -108,7 +108,7 @@ class MockProcess(object):
         return None
 
     def __repr__(self):
-        return "<MockProcess at {0}>".format(hex(id(self)))
+        return "<MockProcess at {}>".format(hex(id(self)))
 
 
 class PopenProcess(object):
@@ -175,7 +175,7 @@ class PopenProcess(object):
         return self.process.pid
 
     def __repr__(self):
-        return "<PopenProcess at {0} (pid={1})>".format(hex(id(self)), self.pid())
+        return "<PopenProcess at {} (pid={})>".format(hex(id(self)), self.pid())
 
 
 class SpurProcess(object):
@@ -228,7 +228,7 @@ class SpurProcess(object):
         return self.process.pid
 
     def __repr__(self):
-        return "<SpurProcess at {0} (pid={1})>".format(hex(id(self)), self.pid())
+        return "<SpurProcess at {} (pid={})>".format(hex(id(self)), self.pid())
 
 
 class OptionMap(collections.MutableMapping):
@@ -271,7 +271,7 @@ class OptionMap(collections.MutableMapping):
         return self.copy()
 
     def __repr__(self):
-        return "{0}({1})".format(type(self).__name__, dict(self.items()))
+        return "{}({})".format(type(self).__name__, dict(self.items()))
 
 
 def _popen_engine(command, engine_cls, setpgrp=False, _popen_lock=threading.Lock(), **kwargs):

--- a/chess/gaviota.py
+++ b/chess/gaviota.py
@@ -21,12 +21,12 @@ import collections
 import ctypes
 import ctypes.util
 import fnmatch
+import logging
 import os
 import os.path
-import logging
 import struct
-import chess
 
+import chess
 
 LOGGER = logging.getLogger(__name__)
 
@@ -2097,14 +2097,7 @@ def open_tablebases(directory, libgtb=None, LibraryLoader=ctypes.cdll):
     except (OSError, RuntimeError) as err:
         LOGGER.info("Falling back to pure Python tablebases: %r", err)
 
-    try:
-        import lzma
-    except ImportError:
-        try:
-            from backports import lzma
-        except ImportError:
-            raise ImportError("chess.gaviota requires backports.lzma or libgtb")
-
+    import lzma
     tables = PythonTablebases(lzma)
     tables.open_directory(directory)
     return tables

--- a/chess/gaviota.py
+++ b/chess/gaviota.py
@@ -376,7 +376,7 @@ def norm_kkindex(x, y):
     rowx = chess.square_rank(x)
     colx = chess.square_file(x)
 
-    if (rowx > colx):
+    if rowx > colx:
         x = flip_nw_se(x)
         y = flip_nw_se(y)
 
@@ -745,15 +745,15 @@ def kaabk_pctoindex(c):
     ws = c.white_piece_squares[:N_WHITE]
     bs = c.black_piece_squares[:N_BLACK]
 
-    if ((ft & WE_FLAG) != 0):
+    if (ft & WE_FLAG) != 0:
         ws = [flip_we(i) for i in ws]
         bs = [flip_we(i) for i in bs]
 
-    if ((ft & NS_FLAG) != 0):
+    if (ft & NS_FLAG) != 0:
         ws = [flip_ns(i) for i in ws]
         bs = [flip_ns(i) for i in bs]
 
-    if ((ft & NW_SE_FLAG) != 0):
+    if (ft & NW_SE_FLAG) != 0:
         ws = [flip_nw_se(i) for i in ws]
         bs = [flip_nw_se(i) for i in bs]
 
@@ -1400,14 +1400,14 @@ def bestx(side, a, b):
 
     xorkey = [0, 3]
 
-    if (a == iFORBID):
+    if a == iFORBID:
         return b
-    if (b == iFORBID):
+    if b == iFORBID:
         return a
 
     retu = [a, a, b, b]
 
-    if (b < a):
+    if b < a:
         retu[1] = b
         retu[2] = a
 

--- a/chess/gaviota.py
+++ b/chess/gaviota.py
@@ -1534,7 +1534,7 @@ class PythonTablebases(object):
         """Loads *.gtb.cp4* tables from a directory."""
         directory = os.path.abspath(directory)
         if not os.path.isdir(directory):
-            raise IOError("not a directory: {0}".format(repr(directory)))
+            raise IOError("not a directory: {}".format(repr(directory)))
 
         for tbfile in fnmatch.filter(os.listdir(directory), "*.gtb.cp4"):
             self.available_tables[os.path.basename(tbfile).replace(".gtb.cp4", "")] = os.path.join(directory, tbfile)
@@ -1565,7 +1565,7 @@ class PythonTablebases(object):
         """
         # Can not probe positions with castling rights.
         if board.castling_rights:
-            raise KeyError("gaviota tables do not contain positions with castling rights: {0}".format(board.fen()))
+            raise KeyError("gaviota tables do not contain positions with castling rights: {}".format(board.fen()))
 
         # Prepare the tablebase request.
         white = [(square, board.piece_type_at(square)) for square in chess.SquareSet(board.occupied_co[chess.WHITE])]
@@ -1582,7 +1582,7 @@ class PythonTablebases(object):
 
         # Only up to 5-men tablebases.
         if len(white_squares) + len(black_squares) > 5:
-            raise KeyError("gaviota tables support up to 5 pieces, not {0}: {1}".format(chess.popcount(board.occupied), board.fen()))
+            raise KeyError("gaviota tables support up to 5 pieces, not {}: {}".format(chess.popcount(board.occupied), board.fen()))
 
         # Probe.
         dtm = self.egtb_get_dtm(req)
@@ -1684,7 +1684,7 @@ class PythonTablebases(object):
             if req.epsq != NOSQUARE:
                 req.epsq = flip_ns(req.epsq)
         else:
-            raise MissingTableError("no gaviota table available for: {0}v{1}".format(white_letters.upper(), black_letters.upper()))
+            raise MissingTableError("no gaviota table available for: {}v{}".format(white_letters.upper(), black_letters.upper()))
 
         return self._open_tablebase(req)
 
@@ -1931,7 +1931,7 @@ class NativeTablebases(object):
 
     def open_directory(self, directory):
         if not os.path.isdir(directory):
-            raise IOError("not a directory: {0}".format(repr(directory)))
+            raise IOError("not a directory: {}".format(repr(directory)))
 
         self.paths.append(directory)
         self._tb_restart()
@@ -1989,10 +1989,10 @@ class NativeTablebases(object):
             return 0
 
         if board.castling_rights:
-            raise KeyError("gaviota tables do not contain positions with castling rights: {0}".format(board.fen()))
+            raise KeyError("gaviota tables do not contain positions with castling rights: {}".format(board.fen()))
 
         if chess.popcount(board.occupied) > 5:
-            raise KeyError("gaviota tables support up to 5 pieces, not {0}: {1}".format(chess.popcount(board.occupied), board.fen()))
+            raise KeyError("gaviota tables support up to 5 pieces, not {}: {}".format(chess.popcount(board.occupied), board.fen()))
 
         stm = ctypes.c_uint(0 if board.turn == chess.WHITE else 1)
         ep_square = ctypes.c_uint(board.ep_square if board.ep_square else 64)
@@ -2032,11 +2032,11 @@ class NativeTablebases(object):
 
         # Probe forbidden.
         if info.value == 3:
-            raise MissingTableError("gaviota table for {0} not available".format(board.fen()))
+            raise MissingTableError("gaviota table for {} not available".format(board.fen()))
 
         # Probe failed or unknown.
         if not ret or info.value == 7:
-            raise KeyError("gaviota probe failed for {0}".format(board.fen()))
+            raise KeyError("gaviota probe failed for {}".format(board.fen()))
 
         # Draw.
         if info.value == 0:

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import chess
 import collections
 import itertools
-import re
 import logging
+import re
 
+import chess
 
 LOGGER = logging.getLogger(__name__)
 
@@ -890,11 +890,7 @@ def read_game(handle, Visitor=GameModelCreator):
 
     >>> pgn_string = "1. e4 e5 2. Nf3 *"
     >>>
-    >>> try:
-    ...     from StringIO import StringIO  # Python 2
-    ... except ImportError:
-    ...     from io import StringIO  # Python 3
-    ...
+    >>> from io import StringIO
     >>> pgn = StringIO(pgn_string)
     >>> game = chess.pgn.read_game(pgn)
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -528,9 +528,9 @@ class Headers(collections.MutableMapping):
         if key in TAG_ROSTER:
             self._tag_roster[key] = value
         elif not TAG_NAME_REGEX.match(key):
-            raise ValueError("non-alphanumeric pgn header tag: {0}".format(repr(key)))
+            raise ValueError("non-alphanumeric pgn header tag: {}".format(repr(key)))
         elif "\n" in value or "\r" in value:
-            raise ValueError("line break in pgn header {0}: {1}".format(key, repr(value)))
+            raise ValueError("line break in pgn header {}: {}".format(key, repr(value)))
         else:
             self._others[key] = value
 
@@ -564,9 +564,9 @@ class Headers(collections.MutableMapping):
         return self.copy()
 
     def __repr__(self):
-        return "{0}({1})".format(
+        return "{}({})".format(
             type(self).__name__,
-            ", ".join("{0}={1}".format(key, repr(value)) for key, value in self.items()))
+            ", ".join("{}={}".format(key, repr(value)) for key, value in self.items()))
 
 
 class BaseVisitor(object):
@@ -759,7 +759,7 @@ class StringExporter(BaseVisitor):
     def visit_header(self, tagname, tagvalue):
         if self.headers:
             self.found_headers = True
-            self.write_line("[{0} \"{1}\"]".format(tagname, tagvalue))
+            self.write_line("[{} \"{}\"]".format(tagname, tagvalue))
 
     def end_headers(self):
         if self.found_headers:
@@ -850,7 +850,7 @@ class FileExporter(StringExporter):
         return None
 
     def __repr__(self):
-        return "<FileExporter at {0}>".format(hex(id(self)))
+        return "<FileExporter at {}>".format(hex(id(self)))
 
     def __str__(self):
         return self.__repr__()

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -262,12 +262,11 @@ def board(board=None, squares=None, flipped=False, coordinates=True, lastmove=No
                 "class": "arrow",
             })
 
-            marker = []
-            marker.append((xtip, ytip))
-            marker.append((shaft_x + dy * 0.5 * marker_size / hypot,
-                           shaft_y - dx * 0.5 * marker_size / hypot))
-            marker.append((shaft_x - dy * 0.5 * marker_size / hypot,
-                           shaft_y + dx * 0.5 * marker_size / hypot))
+            marker = [(xtip, ytip),
+                      (shaft_x + dy * 0.5 * marker_size / hypot,
+                       shaft_y - dx * 0.5 * marker_size / hypot),
+                      (shaft_x - dy * 0.5 * marker_size / hypot,
+                       shaft_y + dx * 0.5 * marker_size / hypot)]
 
             ET.SubElement(svg, "polygon", {
                 "points": " ".join(str(x) + "," + str(y) for x, y in marker),

--- a/chess/syzygy.py
+++ b/chess/syzygy.py
@@ -569,9 +569,8 @@ class Table(object):
 
         black_part, white_part = tablename.split("v")
         if self.has_pawns:
-            self.pawns = {}
-            self.pawns[0] = white_part.count("P")
-            self.pawns[1] = black_part.count("P")
+            self.pawns = {0: white_part.count("P"),
+                          1: black_part.count("P")}
             if self.pawns[1] > 0 and (self.pawns[0] == 0 or self.pawns[1] < self.pawns[0]):
                 self.pawns[0], self.pawns[1] = self.pawns[1], self.pawns[0]
         else:
@@ -1052,13 +1051,11 @@ class WdlTable(Table):
             self.precomp = {}
             self.pieces = {}
 
-            self.factor = {}
-            self.factor[0] = [0 for _ in range(TBPIECES)]  # White
-            self.factor[1] = [0 for _ in range(TBPIECES)]  # Black
+            self.factor = {0: [0 for _ in range(TBPIECES)],
+                           1: [0 for _ in range(TBPIECES)]}
 
-            self.norm = {}
-            self.norm[0] = [0 for _ in range(self.num)]  # White
-            self.norm[1] = [0 for _ in range(self.num)]  # Black
+            self.norm = {0: [0 for _ in range(self.num)],
+                         1: [0 for _ in range(self.num)]}
 
             # Used if there are pawns.
             self.files = [PawnFileData() for _ in range(4)]

--- a/chess/syzygy.py
+++ b/chess/syzygy.py
@@ -1538,7 +1538,7 @@ class Tablebases(object):
         try:
             table = self.wdl[key]
         except KeyError:
-            raise MissingTableError("did not find wdl table {0}".format(key))
+            raise MissingTableError("did not find wdl table {}".format(key))
 
         self._bump_lru(table)
 
@@ -1658,11 +1658,11 @@ class Tablebases(object):
         """
         # Positions with castling rights are not in the tablebase.
         if board.castling_rights:
-            raise KeyError("syzygy tables do not contain positions with castling rights: {0}".format(board.fen()))
+            raise KeyError("syzygy tables do not contain positions with castling rights: {}".format(board.fen()))
 
         # Validate piece count.
         if chess.popcount(board.occupied) > 7:
-            raise KeyError("syzygy tables support up to 6 (and experimentally 7) pieces, not {0}: {1}".format(chess.popcount(board.occupied), board.fen()))
+            raise KeyError("syzygy tables support up to 6 (and experimentally 7) pieces, not {}: {}".format(chess.popcount(board.occupied), board.fen()))
 
         # Probe.
         v, _ = self.probe_ab(board, -2, 2)
@@ -1708,7 +1708,7 @@ class Tablebases(object):
         try:
             table = self.dtz[key]
         except KeyError:
-            raise MissingTableError("did not find dtz table {0}".format(key))
+            raise MissingTableError("did not find dtz table {}".format(key))
 
         self._bump_lru(table)
 

--- a/chess/syzygy.py
+++ b/chess/syzygy.py
@@ -16,15 +16,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import chess
 import collections
 import mmap
 import os
+import re
 import struct
 import sys
 import threading
-import re
 
+import chess
 
 UINT64_BE = struct.Struct(">Q")
 UINT32 = struct.Struct("<I")
@@ -605,13 +605,7 @@ class Table(object):
             self.data = mmap.mmap(self.fd, 0, access=mmap.ACCESS_READ)
 
             # Micro optimizations for read_uint8.
-            if sys.version_info >= (3, ):
-                self.read_uint8 = self.data.__getitem__
-            else:
-                def read_uint8(data_ptr):
-                    return ord(self.data[data_ptr])
-
-                self.read_uint8 = read_uint8
+            self.read_uint8 = self.data.__getitem__
 
     def check_magic(self, magic):
         return all(self.read_uint8(i) == m for i, m in enumerate(magic))

--- a/chess/uci.py
+++ b/chess/uci.py
@@ -758,10 +758,7 @@ class Engine(object):
             if name.lower() == "uci_variant":
                 self.uci_variant = value.lower()
 
-            builder = []
-            builder.append("setoption name")
-            builder.append(name)
-            builder.append("value")
+            builder = ["setoption name", name, "value"]
             if value is True:
                 builder.append("true")
             elif value is False:
@@ -870,8 +867,7 @@ class Engine(object):
                 board.push(switchyard.pop())
 
         # Send starting position.
-        builder = []
-        builder.append("position")
+        builder = ["position"]
 
         if uci_variant == "chess" and board.fen() == chess.STARTING_FEN:
             builder.append("startpos")
@@ -946,8 +942,7 @@ class Engine(object):
         for info_handler in self.info_handlers:
             info_handler.on_go()
 
-        builder = []
-        builder.append("go")
+        builder = ["go"]
 
         if ponder:
             builder.append("ponder")

--- a/chess/uci.py
+++ b/chess/uci.py
@@ -705,6 +705,7 @@ class Engine(object):
         In debug mode, the engine should send additional information to the
         GUI to help with the debugging. Usually, this mode is off by default.
 
+        :param async_callback:
         :param on: bool
 
         :return: Nothing
@@ -742,6 +743,7 @@ class Engine(object):
         """
         Set values for the engine's available options.
 
+        :param async_callback:
         :param options: A dictionary with option names as keys.
 
         :return: Nothing
@@ -818,6 +820,7 @@ class Engine(object):
         If the position is from a new game, it is recommended to use the
         *ucinewgame* command before the *position* command.
 
+        :param async_callback:
         :param board: A *chess.Board*.
 
         :return: Nothing
@@ -902,6 +905,7 @@ class Engine(object):
         Note that when using *infinite* or *ponder*, the engine will not stop
         until it is told to.
 
+        :param async_callback:
         :param searchmoves: Restrict search to moves in this list.
         :param ponder: Bool to enable pondering mode. The engine will not stop
             pondering in the background until a *stop* command is received.
@@ -1140,6 +1144,9 @@ def popen_engine(command, engine_cls=Engine, setpgrp=False, _popen_lock=threadin
     >>> engine.author
     'T. Romstad, M. Costalba, J. Kiiski, G. Linscott'
 
+    :param command:
+    :param engine_cls:
+    :param _popen_lock:
     :param setpgrp: Open the engine process in a new process group. This will
         stop signals (such as keyboard interrupts) from propagating from the
         parent process. Defaults to ``False``.

--- a/chess/uci.py
+++ b/chess/uci.py
@@ -84,11 +84,7 @@ class InfoHandler(object):
     def __init__(self):
         self.lock = threading.Lock()
 
-        self.info = {}
-        self.info["refutation"] = {}
-        self.info["currline"] = {}
-        self.info["pv"] = {}
-        self.info["score"] = {}
+        self.info = {"refutation": {}, "currline": {}, "pv": {}, "score": {}}
 
     def depth(self, x):
         """Receives the search depth in plies."""

--- a/chess/variant.py
+++ b/chess/variant.py
@@ -558,9 +558,11 @@ class ThreeCheckBoard(chess.Board):
         self.remaining_checks[chess.BLACK] = bc
 
     def epd(self, shredder=False, en_passant="legal", promoted=None, **operations):
-        epd = []
-        epd.append(super(ThreeCheckBoard, self).epd(shredder=shredder, en_passant=en_passant, promoted=promoted))
-        epd.append("%d+%d" % (max(self.remaining_checks[chess.WHITE], 0), max(self.remaining_checks[chess.BLACK], 0)))
+        epd = [super(ThreeCheckBoard, self).epd(shredder=shredder,
+                                                en_passant=en_passant,
+                                                promoted=promoted), "%d+%d" % (
+               max(self.remaining_checks[chess.WHITE], 0),
+               max(self.remaining_checks[chess.BLACK], 0))]
         if operations:
             epd.append(self._epd_operations(operations))
         return " ".join(epd)

--- a/chess/variant.py
+++ b/chess/variant.py
@@ -516,7 +516,7 @@ class ThreeCheckBoard(chess.Board):
         # Split into 5 or 6 parts.
         parts = epd.strip().rstrip(";").split(None, 5)
         if len(parts) < 5:
-            raise ValueError("three-check epd should consist of at least 5 parts: {0}".format(repr(epd)))
+            raise ValueError("three-check epd should consist of at least 5 parts: {}".format(repr(epd)))
 
         # Parse ops.
         if len(parts) > 5:
@@ -534,7 +534,7 @@ class ThreeCheckBoard(chess.Board):
     def set_fen(self, fen):
         parts = fen.split()
         if len(parts) != 7:
-            raise ValueError("three-check fen should consist of 7 parts: {0}".format(repr(fen)))
+            raise ValueError("three-check fen should consist of 7 parts: {}".format(repr(fen)))
 
         # Extract check part.
         if parts[6][0] == "+":
@@ -543,14 +543,14 @@ class ThreeCheckBoard(chess.Board):
                 w, b = check_part.split("+", 1)
                 wc, bc = 3 - int(w), 3 - int(b)
             except ValueError:
-                raise ValueError("invalid check part in lichess three-check fen: {0}".format(repr(check_part)))
+                raise ValueError("invalid check part in lichess three-check fen: {}".format(repr(check_part)))
         else:
             check_part = parts.pop(4)
             try:
                 w, b = check_part.split("+", 1)
                 wc, bc = int(w), int(b)
             except ValueError:
-                raise ValueError("invalid check part in three-check fen: {0}".format(repr(check_part)))
+                raise ValueError("invalid check part in three-check fen: {}".format(repr(check_part)))
 
         # Set fen.
         super(ThreeCheckBoard, self).set_fen(" ".join(parts))
@@ -623,7 +623,7 @@ class CrazyhousePocket(object):
         return sum(self.pieces.values())
 
     def __repr__(self):
-        return "CrazyhousePocket('{0}')".format(str(self))
+        return "CrazyhousePocket('{}')".format(str(self))
 
     def copy(self):
         pocket = type(self)()
@@ -753,7 +753,7 @@ class CrazyhouseBoard(chess.Board):
                 uci = "P" + uci
             move = chess.Move.from_uci(uci)
             if not self.is_legal(move):
-                raise ValueError("illegal drop san: {0} in {1}".format(repr(san), self.fen()))
+                raise ValueError("illegal drop san: {} in {}".format(repr(san), self.fen()))
             return move
         else:
             return super(CrazyhouseBoard, self).parse_san(san)
@@ -774,7 +774,7 @@ class CrazyhouseBoard(chess.Board):
         # Transform to lichess-style ZH FEN.
         if position_part.endswith("]"):
             if position_part.count("/") != 7:
-                raise ValueError("expected 8 rows in position part of zh fen: {0}", format(repr(fen)))
+                raise ValueError("expected 8 rows in position part of zh fen: {}", format(repr(fen)))
             position_part = position_part[:-1].replace("[", "/", 1)
 
         # Split off pocket part.
@@ -839,4 +839,4 @@ def find_variant(name):
     for variant in VARIANTS:
         if any(alias.lower() == name.lower() for alias in variant.aliases):
             return variant
-    raise ValueError("unsupported variant: {0}".format(name))
+    raise ValueError("unsupported variant: {}".format(name))

--- a/chess/variant.py
+++ b/chess/variant.py
@@ -574,10 +574,10 @@ class ThreeCheckBoard(chess.Board):
         return self.remaining_checks[chess.WHITE] <= 0 and self.remaining_checks[chess.BLACK] <= 0
 
     def is_variant_loss(self):
-        return self.remaining_checks[not self.turn] <= 0 and self.remaining_checks[self.turn] > 0
+        return self.remaining_checks[not self.turn] <= 0 < self.remaining_checks[self.turn]
 
     def is_variant_win(self):
-        return self.remaining_checks[self.turn] <= 0 and self.remaining_checks[not self.turn] > 0
+        return self.remaining_checks[self.turn] <= 0 < self.remaining_checks[not self.turn]
 
     def is_irreversible(self, move):
         if super(ThreeCheckBoard, self).is_irreversible(move):

--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -678,6 +678,7 @@ class Engine(object):
         """
         Tells the engine whether to ponder or not.
 
+        :param async_callback:
         :param ponder: ``True`` or ``False`` to set *ponder* on or off, respectively.
             Defaults to ``True``.
 
@@ -714,6 +715,7 @@ class Engine(object):
         """
         Command used to tell the engine whether to output its analysis or not.
 
+        :param async_callback:
         :param flag: ``True`` or ``False`` to set *post* on or off, respectively.
 
         :return: Nothing.
@@ -774,6 +776,7 @@ class Engine(object):
         Sets values for the engine's available options.
         For 'button', 'reset' and 'save', flips the engine's value.
 
+        :param async_callback:
         :param options: A dictionary with option names as keys.
 
         :return: Nothing.
@@ -831,6 +834,7 @@ class Engine(object):
         """
         Sets up a given board position.
 
+        :param async_callback:
         :param board: A :class:`~chess.Board` instance.
 
         :return: Nothing.
@@ -885,6 +889,7 @@ class Engine(object):
         """
         Sets the maximum memory of the engine's hash/pawn/bitbase/other tables.
 
+        :param async_callback:
         :param amount: The maximum amount of memory to use in megabytes (MB).
 
         :return: Nothing.
@@ -900,6 +905,7 @@ class Engine(object):
         Sets the maximum number of processor cores the engine is allowed to use.
         For an SMP engine, this corresponds to search threads.
 
+        :param async_callback:
         :param num: The number of processor cores or search threads allowed.
 
         :return: Nothing.
@@ -928,6 +934,7 @@ class Engine(object):
         Sets the side to move, sets the engine to move for the opposite side
         and exits *force* mode.
 
+        :param async_callback:
         :param color: The desired side to move.
 
         :return: Nothing.
@@ -978,6 +985,7 @@ class Engine(object):
         Informs the engine of its opponent's name.
         The engine may choose to play differently based on this parameter.
 
+        :param async_callback:
         :param name_str: The name of the opponent.
 
         :return: Nothing.
@@ -990,6 +998,7 @@ class Engine(object):
         Informs the engine of its own rating followed by the opponent's.
         The engine may choose to play differently based on these parameters.
 
+        :param async_callback:
         :param engine_rating: The rating of this engine.
         :param opponent_rating: The rating of the opponent.
 
@@ -1017,6 +1026,7 @@ class Engine(object):
         the engine may have *feature egt=syzygy*, then it is legal to call
         *egtpath("syzygy", "<path-to-syzygy>")*.
 
+        :param async_callback:
         :param egt_type: The type of EGT pointed to (syzygy, gaviota, etc.).
         :param egt_path: The path to the desired EGT.
 
@@ -1034,6 +1044,7 @@ class Engine(object):
         Tells the engine to limit its speed of search in terms of
         nodes per second (NPS) to the provided value.
 
+        :param async_callback:
         :param target_nps: The limiting nodes per second (NPS) value.
 
         :return: Nothing.
@@ -1048,6 +1059,7 @@ class Engine(object):
         """
         Sets the maximum time the engine is to search for.
 
+        :param async_callback:
         :param time: The amount of time to search for in seconds.
 
         :return: Nothing.
@@ -1061,6 +1073,7 @@ class Engine(object):
         """
         Sets the maximum depth the engine is to search for.
 
+        :param async_callback:
         :param depth: The depth (plies) to search for.
 
         :return: Nothing.
@@ -1074,6 +1087,7 @@ class Engine(object):
         """
         Synchronizes the engine's clock with the total amount of time left.
 
+        :param async_callback:
         :param time: The total time left in centiseconds.
 
         :return: Nothing.
@@ -1088,6 +1102,7 @@ class Engine(object):
         """
         Synchronizes the engine's clock with the total amount of time left.
 
+        :param async_callback:
         :param time: The total time left in centiseconds.
 
         :return: Nothing.
@@ -1102,6 +1117,7 @@ class Engine(object):
         """
         Sets the time controls for the game.
 
+        :param async_callback:
         :param movestogo: The number of moves to be played before the time
             control repeats.
             Defaults to ``0`` (in order to play the whole game in the given
@@ -1298,6 +1314,7 @@ class Engine(object):
         If *auto_force* is set to ``True``, the engine will not start
         thinking about its next move immediately after.
 
+        :param async_callback:
         :param move: The move to play in XBoard notation.
 
         :return: Nothing.
@@ -1427,6 +1444,7 @@ class Engine(object):
         Only used with variants that the engine announced it could play in the
         'feature variants="variant,variant,..."' command at startup.
 
+        :param async_callback:
         :param variant: The variant name to play.
 
         :return: Nothing.
@@ -1449,6 +1467,9 @@ def popen_engine(command, engine_cls=Engine, setpgrp=False, _popen_lock=threadin
     >>> engine = chess.xboard.popen_engine("/usr/games/crafty")
     >>> engine.xboard()
 
+    :param command:
+    :param engine_cls:
+    :param _popen_lock:
     :param setpgrp: Opens the engine process in a new process group. This will
         stop signals (such as keyboard interrupts) from propagating from the
         parent process. Defaults to ``False``.

--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -168,8 +168,7 @@ class PostHandler(object):
     def __init__(self):
         self.lock = threading.Lock()
 
-        self.post = {}
-        self.post["pv"] = {}
+        self.post = {"pv": {}}
 
     def depth(self, depth):
         """Receives the search depth in plies."""

--- a/chess/xboard.py
+++ b/chess/xboard.py
@@ -844,9 +844,8 @@ class Engine(object):
         # Setboard should be sent after force.
         self.force()
 
-        builder = []
-        builder.append("setboard")
-        builder.append(board.shredder_fen() if board.chess960 else board.fen())
+        builder = ["setboard",
+                   board.shredder_fen() if board.chess960 else board.fen()]
 
         self.board = board.copy(stack=False)
 
@@ -1122,9 +1121,7 @@ class Engine(object):
         """
         self._assert_not_busy("level")
 
-        builder = []
-        builder.append("level")
-        builder.append(str(int(movestogo)))
+        builder = ["level", str(int(movestogo))]
 
         if seconds is not None:
             builder.append(str(int(minutes)) + ":" + str(int(seconds)))

--- a/docs/gaviota.rst
+++ b/docs/gaviota.rst
@@ -10,17 +10,6 @@ castling rights are not included.
 .. autoclass:: chess.gaviota.PythonTablebases
     :members:
 
-backports.lzma
---------------
-
-For Python versions before 3.3 you have to install ``backports.lzma`` in order
-to use the pure Python probing code.
-
-.. code-block:: shell
-
-    sudo apt-get install liblzma-dev libpython2.7-dev
-    pip install backports.lzma
-
 libgtb
 ------
 

--- a/examples/polyglot_tree.py
+++ b/examples/polyglot_tree.py
@@ -21,7 +21,7 @@ def print_tree(args, visited, level=0):
     visited.add(zobrist_hash)
 
     for entry in args.book.find_all(zobrist_hash):
-        print("{0}├─ \033[1m{1}\033[0m (weight: {2}, learn: {3})".format(
+        print("{}├─ \033[1m{}\033[0m (weight: {}, learn: {})".format(
             "|  " * level,
             args.board.san(entry.move()),
             entry.weight,

--- a/release.py
+++ b/release.py
@@ -39,9 +39,9 @@ def check_changelog():
         print("Found: Upcoming in the next release")
         sys.exit(1)
 
-    tagname = "v{0}".format(chess.__version__)
+    tagname = "v{}".format(chess.__version__)
     if tagname not in changelog:
-        print("Not found: {0}".format(tagname))
+        print("Not found: {}".format(tagname))
         sys.exit(1)
 
 
@@ -52,15 +52,15 @@ def check_docs():
 
 def tag_and_push():
     print("--- TAG AND PUSH -------------------------------------------------")
-    tagname = "v{0}".format(chess.__version__)
-    release_filename = "release-{0}.txt".format(tagname)
+    tagname = "v{}".format(chess.__version__)
+    release_filename = "release-{}.txt".format(tagname)
 
     if not os.path.exists(release_filename):
-        print(">>> Creating {0} ...".format(release_filename))
+        print(">>> Creating {} ...".format(release_filename))
         first_section = False
         prev_line = None
         with open(release_filename, "w") as release_txt, open("CHANGELOG.rst", "r") as changelog_file:
-            headline = "python-chess {0}".format(tagname)
+            headline = "python-chess {}".format(tagname)
             release_txt.write(headline + os.linesep)
 
             for line in changelog_file:
@@ -85,11 +85,11 @@ def tag_and_push():
 
     guessed_tagname = input(">>> Sure? Confirm tagname: ")
     if guessed_tagname != tagname:
-        print("Actual tagname is: {0}".format(tagname))
+        print("Actual tagname is: {}".format(tagname))
         sys.exit(1)
 
-    system("git tag {0} -s -F {1}".format(tagname, release_filename))
-    system("git push --atomic origin master {0}".format(tagname))
+    system("git tag {} -s -F {}".format(tagname, release_filename))
+    system("git push --atomic origin master {}".format(tagname))
     return tagname
 
 
@@ -105,7 +105,7 @@ def pypi():
 
 def github_release(tagname):
     print("--- GITHUB RELEASE -----------------------------------------------")
-    print("https://github.com/niklasf/python-chess/releases/new?tag={0}".format(tagname))
+    print("https://github.com/niklasf/python-chess/releases/new?tag={}".format(tagname))
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,7 @@ def read_description():
 
 
 def extra_dependencies():
-    extras = {}
-    extras["engine"] = []
+    extras = {"engine": []}
 
     if platform.python_implementation() == "CPython":
         extras["gaviota"] = []

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import chess
 import io
 import os
-import setuptools
-import sys
 import platform
 import re
+import sys
+
+import setuptools
+
+import chess
+
+if sys.version_info < (3, ):
+    raise ImportError(
+        """You are installing python-chess on Python 2.
+
+Python 2 support has been dropped. Consider upgrading to Python 3, or using
+the 0.23.x branch, which will be maintained until the end of 2018.
+""")
 
 
 def read_description():
@@ -56,17 +66,10 @@ def read_description():
 
 def extra_dependencies():
     extras = {}
-
-    if sys.version_info < (3, 2):
-        extras["engine"] = ["futures"]
-    else:
-        extras["engine"] = []
+    extras["engine"] = []
 
     if platform.python_implementation() == "CPython":
-        if sys.version_info < (3, 3):
-            extras["gaviota"] = ["backports.lzma"]
-        else:
-            extras["gaviota"] = []
+        extras["gaviota"] = []
 
     extras["test"] = extras["engine"] + extras.get("gaviota", [])
 
@@ -88,7 +91,7 @@ setuptools.setup(
     url="https://github.com/niklasf/python-chess",
     packages=["chess"],
     test_suite="test",
-    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*",
+    python_requires=">=3.3",
     extras_require=extra_dependencies(),
     tests_require=extra_dependencies().get("test"),
     classifiers=[
@@ -98,13 +101,12 @@ setuptools.setup(
         "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3 :: Only",
         "Topic :: Games/Entertainment :: Board Games",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],

--- a/setup.py
+++ b/setup.py
@@ -46,17 +46,17 @@ def read_description():
     # Link to the documentation of the specific version.
     description = description.replace(
         "//python-chess.readthedocs.io/en/latest/",
-        "//python-chess.readthedocs.io/en/v{0}/".format(chess.__version__))
+        "//python-chess.readthedocs.io/en/v{}/".format(chess.__version__))
 
     # Use documentation badge for the specific version.
     description = description.replace(
         "//readthedocs.org/projects/python-chess/badge/?version=latest",
-        "//readthedocs.org/projects/python-chess/badge/?version=v{0}".format(chess.__version__))
+        "//readthedocs.org/projects/python-chess/badge/?version=v{}".format(chess.__version__))
 
     # Show Travis CI build status of the concrete version.
     description = description.replace(
         "//travis-ci.org/niklasf/python-chess.svg?branch=master",
-        "//travis-ci.org/niklasf/python-chess.svg?branch=v{0}".format(chess.__version__))
+        "//travis-ci.org/niklasf/python-chess.svg?branch=v{}".format(chess.__version__))
 
     # Remove doctest comments.
     description = re.sub("\s*# doctest:.*", "", description)

--- a/test.py
+++ b/test.py
@@ -625,9 +625,9 @@ class BoardTestCase(unittest.TestCase):
             board.variation_san([chess.Move.from_uci(m) for m in illegal_variation])
         message = str(err.exception)
         self.assertIn('illegal move', message.lower(),
-                      msg="Error [{0}] mentions illegal move".format(message))
+                      msg="Error [{}] mentions illegal move".format(message))
         self.assertIn('f3h6', message,
-                      msg="Illegal move f3h6 appears in message [{0}]".format(message))
+                      msg="Illegal move f3h6 appears in message [{}]".format(message))
 
     def test_move_stack_usage(self):
         board = chess.Board()
@@ -3005,13 +3005,13 @@ class SyzygyTestCase(unittest.TestCase):
         for name in names:
             self.assertTrue(
                 chess.syzygy.normalize_tablename(name) in names,
-                "Already normalized {0}".format(name))
+                "Already normalized {}".format(name))
 
             w, b = name.split("v", 1)
             swapped = b + "v" + w
             self.assertTrue(
                 chess.syzygy.normalize_tablename(swapped) in names,
-                "Normalized {0}".format(swapped))
+                "Normalized {}".format(swapped))
 
     def test_normalize_nnvbb(self):
         self.assertEqual(chess.syzygy.normalize_tablename("KNNvKBB"), "KBBvKNN")
@@ -3115,17 +3115,17 @@ class SyzygyTestCase(unittest.TestCase):
                 wdl_table = tables.probe_wdl_table(board)
                 self.assertEqual(
                     wdl_table, extra["wdl_table"],
-                    "Expecting wdl_table {0} for {1}, got {2} (at line {3})".format(extra["wdl_table"], board.fen(), wdl_table, line + 1))
+                    "Expecting wdl_table {} for {}, got {} (at line {})".format(extra["wdl_table"], board.fen(), wdl_table, line + 1))
 
                 wdl = tables.probe_wdl(board)
                 self.assertEqual(
                     wdl, extra["wdl"],
-                    "Expecting wdl {0} for {1}, got {2} (at line {3})".format(extra["wdl"], board.fen(), wdl, line + 1))
+                    "Expecting wdl {} for {}, got {} (at line {})".format(extra["wdl"], board.fen(), wdl, line + 1))
 
                 dtz = tables.probe_dtz(board)
                 self.assertEqual(
                     dtz, extra["dtz"],
-                    "Expecting dtz {0} for {1}, got {2} (at line {3})".format(extra["dtz"], board.fen(), dtz, line + 1))
+                    "Expecting dtz {} for {}, got {} (at line {})".format(extra["dtz"], board.fen(), dtz, line + 1))
 
     @catchAndSkip(chess.syzygy.MissingTableError)
     def test_stockfish_dtz_bug(self):
@@ -3151,7 +3151,7 @@ class SyzygyTestCase(unittest.TestCase):
                 wdl = tables.probe_wdl(board)
 
                 expected_wdl = ((solution["max_dtm"] > 0) - (solution["max_dtm"] < 0)) * 2
-                self.assertEqual(wdl, expected_wdl, "Expecting wdl {0}, got {1} (in {2})".format(expected_wdl, wdl, epd))
+                self.assertEqual(wdl, expected_wdl, "Expecting wdl {}, got {} (in {})".format(expected_wdl, wdl, epd))
 
                 dtz = tables.probe_dtz(board)
 
@@ -3175,7 +3175,7 @@ class SyzygyTestCase(unittest.TestCase):
                 board, solution = chess.variant.SuicideBoard.from_epd(epd)
 
                 dtz = tables.probe_dtz(board)
-                self.assertEqual(dtz, solution["dtz"], "Expecting dtz {0}, got {1} (in {2})".format(solution["dtz"], dtz, epd))
+                self.assertEqual(dtz, solution["dtz"], "Expecting dtz {}, got {} (in {})".format(solution["dtz"], dtz, epd))
 
     @unittest.skipIf(os.environ.get("TRAVIS_PYTHON_VERSION", "").startswith("pypy"), "travis pypy is very slow")
     @catchAndSkip(chess.syzygy.MissingTableError)
@@ -3187,7 +3187,7 @@ class SyzygyTestCase(unittest.TestCase):
                 solution = board.set_epd(epd)
 
                 dtz = tables.probe_dtz(board)
-                self.assertAlmostEqual(dtz, solution["dtz"], delta=1, msg="Expected dtz {0}, got {1} (in l. {2}, fen: {3})".format(solution["dtz"], dtz, l + 1, board.fen()))
+                self.assertAlmostEqual(dtz, solution["dtz"], delta=1, msg="Expected dtz {}, got {} (in l. {}, fen: {})".format(solution["dtz"], dtz, l + 1, board.fen()))
 
 
 class NativeGaviotaTestCase(unittest.TestCase):
@@ -3248,7 +3248,7 @@ class GaviotaTestCase(unittest.TestCase):
                     expected = extra["dm"] * 2
                 dtm = self.tablebases.probe_dtm(board)
                 self.assertEqual(dtm, expected,
-                    "Expecting dtm {0} for {1}, got {2} (at line {3})".format(expected, board.fen(), dtm, line + 1))
+                    "Expecting dtm {} for {}, got {} (at line {})".format(expected, board.fen(), dtm, line + 1))
 
     @catchAndSkip(chess.gaviota.MissingTableError)
     def test_dm_5(self):
@@ -3269,7 +3269,7 @@ class GaviotaTestCase(unittest.TestCase):
                     expected = extra["dm"] * 2
                 dtm = self.tablebases.probe_dtm(board)
                 self.assertEqual(dtm, expected,
-                    "Expecting dtm {0} for {1}, got {2} (at line {3})".format(expected, board.fen(), dtm, line + 1))
+                    "Expecting dtm {} for {}, got {} (at line {})".format(expected, board.fen(), dtm, line + 1))
 
     def test_wdl(self):
         board = chess.Board("8/8/4K3/2n5/8/3k4/8/8 w - - 0 1")

--- a/test.py
+++ b/test.py
@@ -17,31 +17,28 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import chess
-import chess.polyglot
-import chess.pgn
-import chess.uci
-import chess.xboard
-import chess.syzygy
-import chess.gaviota
-import chess.variant
-import chess.svg
 import collections
 import copy
+import logging
 import os
 import os.path
-import textwrap
-import sys
-import time
-import threading
-import logging
 import platform
+import sys
+import textwrap
+import threading
+import time
 import unittest
+from io import StringIO
 
-try:
-    from StringIO import StringIO  # Python 2
-except ImportError:
-    from io import StringIO  # Python 3
+import chess
+import chess.gaviota
+import chess.pgn
+import chess.polyglot
+import chess.svg
+import chess.syzygy
+import chess.uci
+import chess.variant
+import chess.xboard
 
 
 class RaiseLogHandler(logging.StreamHandler):

--- a/test.py
+++ b/test.py
@@ -1769,7 +1769,7 @@ class PgnTestCase(unittest.TestCase):
         game.accept(exporter)
         self.assertEqual(virtual_file.getvalue(), pgn + "\n\n")
 
-    def test_empty_game(self):
+    def test_game_without_tag_roster(self):
         game = chess.pgn.Game.without_tag_roster()
         self.assertEqual(str(game), "*")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy
+envlist = py33,py34,py35,py36
 
 [testenv]
 passenv = LD_LIBRARY_PATH
 whitelist_externals =
     stockfish
 deps =
-    py27: backports.lzma
-    py27,pypy: futures
-    py27,py33,py34,py35,py36: spur
+    py33,py34,py35,py36: spur
 commands =
     python test.py --verbose
     python -m doctest README.rst --verbose


### PR DESCRIPTION
For https://github.com/niklasf/python-chess/issues/285.

* Following http://python3statement.org/practicalities/, raises an error when importing (`__init__.py) or installing (setup.py)
* Remove redundant Python 2 code
* Update some code for Python 3+ (formatters, lists, dicts)
* Also fix some other code inspections

---

Also, here's the pip installs for python-chess from PyPI for April 2018, showing Python 2 is already has much lower use than Python 3:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 3.5            |  32.51% |            714 |
| 3.4            |  25.50% |            560 |
| 2.7            |  23.00% |            505 |
| 3.6            |  18.99% |            417 |
| Total          |         |          2,196 |

Source: `pypinfo --start-date 2018-04-01 --end-date 2018-04-30 --percent --markdown python-chess pyversion`