### PR TITLE
Counting captured pieces

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1246,6 +1246,28 @@ class BaseBoard:
         board.set_chess960_pos(sharnagl)
         return board
 
+    def count_captured(self, piece, color):
+        """
+        Get the number of captured pieces on the current position.
+
+        :param piece: Type of the piece to count (chess.ROOK, ...)
+        :param color: Color of the piece to check (chess.WHITE or chess.BLACK)
+
+        :raises: :exc:`ValueError` if the piece type is invalid.
+        """
+        if piece == QUEEN:
+            piece_count = 1
+        elif piece in (ROOK, BISHOP, KNIGHT):
+            piece_count = 2
+        elif piece == PAWN:
+            piece_count = 8
+        else:
+            raise ValueError("Unknown piece type '%s'" % piece)
+
+        capture_count = piece_count - popcount(self.pieces_mask(piece, color))
+
+        return capture_count if capture_count >= 0 else 0
+
 
 class _BoardState:
 

--- a/test.py
+++ b/test.py
@@ -1381,6 +1381,23 @@ class BoardTestCase(unittest.TestCase):
         mirrored = chess.Board("r1b1k2r/pp3pp1/2n5/1B1N2q1/3PpPPp/4n2K/PP2N3/R1BQ1R2 b kq g3 0 15")
         self.assertEqual(board.mirror(), mirrored)
 
+    def test_count_captured_pieces(self):
+        # 1. e4 d5 2. exd5 e5 3. d4 exd4 4. d6 Qg5 5. Qh5 Qxc1+
+        # 6. Ke2 c5 7. d7+ Ke7 8. Qg6 Nf6 9. d8=Q+ Ke6 10. Qh6 *
+        board = chess.Board("rnbQ1b1r/pp3ppp/4kn1Q/2p5/3p4/8/PPP1KPPP/RNq2BNR b - - 2 10")
+
+        self.assertEqual(board.count_captured(chess.QUEEN, chess.WHITE), 0)
+        self.assertEqual(board.count_captured(chess.ROOK, chess.WHITE), 0)
+        self.assertEqual(board.count_captured(chess.BISHOP, chess.WHITE), 1)
+        self.assertEqual(board.count_captured(chess.KNIGHT, chess.WHITE), 0)
+        self.assertEqual(board.count_captured(chess.PAWN, chess.WHITE), 2)
+
+        self.assertEqual(board.count_captured(chess.QUEEN, chess.BLACK), 0)
+        self.assertEqual(board.count_captured(chess.ROOK, chess.BLACK), 0)
+        self.assertEqual(board.count_captured(chess.BISHOP, chess.BLACK), 0)
+        self.assertEqual(board.count_captured(chess.KNIGHT, chess.BLACK), 0)
+        self.assertEqual(board.count_captured(chess.PAWN, chess.BLACK), 1)
+
 
 class LegalMoveGeneratorTestCase(unittest.TestCase):
 


### PR DESCRIPTION
I have implemented issue #231.

This method does not count the absolute number of captured pieces, but the difference between the ones on the board and the one that should initially be on the board (see test case).

I've seen that Scid vs PC uses this technique, so I hope it is good enough.