### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def extra_dependencies():
 
 
 setuptools.setup(
-    name="python-chess",
+    name="pythonchess",
     version=chess.__version__,
     author=chess.__author__,
     author_email=chess.__email__,


### PR DESCRIPTION
Hey! Thanks for letting us use your great work. I would suggest you change the name of the module in setup.py to "pythonchess". This way we would be able to pip install it and import the module without being in the main directory. Import statements with a "-" won't work. Thanks, and keep the good work up!