### PR TITLE
Travis CI: Upgrade from Python 3.7 pre-release to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,13 @@ python:
  - "3.4"
  - "3.5"
  - "3.6"
- - "3.7-dev"
  - "pypy3"
 matrix:
   include:
-   - python: "3.7-dev"
+   - python: "3.7"
+     sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+   - python: "3.7"
+     sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
      env: PERFT=1
 cache:
   directories:


### PR DESCRIPTION
Upgrade to the production version of Python 3.7 in alignment with travis-ci/travis-ci#9069

Also see the note about outdated Python versions at:
* https://docs.travis-ci.com/user/languages/python/#development-releases-support