### PR TITLE
Adding type aliases for Color, PieceType, and Square

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -38,10 +38,12 @@ import struct
 
 COLORS = [WHITE, BLACK] = [True, False]
 COLOR_NAMES = ["black", "white"]
+Color = bool
 
 PIECE_TYPES = [PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING] = range(1, 7)
 PIECE_SYMBOLS = [None, "p", "n", "b", "r", "q", "k"]
 PIECE_NAMES = [None, "pawn", "knight", "bishop", "rook", "queen", "king"]
+PieceType = int
 
 UNICODE_PIECE_SYMBOLS = {
     "R": u"♖", "r": u"♜",
@@ -89,6 +91,7 @@ SQUARES = [
     A6, B6, C6, D6, E6, F6, G6, H6,
     A7, B7, C7, D7, E7, F7, G7, H7,
     A8, B8, C8, D8, E8, F8, G8, H8] = range(64)
+Square = int
 
 SQUARE_NAMES = [f + r for r in RANK_NAMES for f in FILE_NAMES]
 


### PR DESCRIPTION
# Motivation

Python 3 added type hinting to allow for more explicit type annotations to be added to python code. Right now colors, piece types, and squares are all raw types (bool, int, and int respectively), which doesn't lend itself to type hinting:

```python
def do_something(color: bool, piece_type: int, square: int):
    ...
```

If you aren't familiar with the python-chess api, you don't know what the values for the parameters mean, could be, or come from.

# Changes

Three [type aliases](https://docs.python.org/3.6/library/typing.html#type-aliases) were added to help this. This makes the above example:

```python
def do_something(color: chess.Color, piece_type: chess.PieceType, square: chess.Square):
    ...
```

This is much more explicit about where the values are coming from.

These additions have no effect on existing code, but does require python 3.5+.
