### PR TITLE
Fix SQUARE_SIZE constant to 50

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -27,7 +27,7 @@ import math
 import xml.etree.ElementTree as ET
 
 
-SQUARE_SIZE = 45
+SQUARE_SIZE = 50
 MARGIN = 20
 
 PIECES = {


### PR DESCRIPTION
This constant is currently wrong. The default size of the SVG chessboard is 400, divide that with 8 (as we have 8 files/ranks) and the result is 50, so the square size is 50. I have noticed in my app that it is off for exactly 5 pixels. Now I finally found the culprit. Please compile a new version of python-chess.