### PR TITLE
Enable support for reversed(GameNode) built-in

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -388,6 +388,19 @@ class GameNode:
     def __str__(self):
         return self.accept(StringExporter(columns=None))
 
+    def __len__(self):
+        """
+        Return the length of the main variation
+        """
+        node = self
+        length = 1
+
+        while node.variations:
+            node = node.variations[0]
+            length += 1
+
+        return length
+
 
 class Game(GameNode):
     """

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -508,7 +508,7 @@ class Headers(collections.MutableMapping):
 
     def is_wild(self):
         # http://www.freechess.org/Help/HelpFiles/wild.html
-        wild = self.get("Variant", "").lower() in [
+        wild = self.get("Variant", "").lower() in [  # noqa E514
             "wild/0", "wild/1", "wild/2", "wild/3", "wild/4", "wild/5",
             "wild/6", "wild/7", "wild/8", "wild/8a"]
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -401,6 +401,32 @@ class GameNode:
 
         return length
 
+    def __getitem__(self, key):
+        """
+        Get the 'key'th child node of this GameNode
+
+        TODO: add support for slices
+        """
+        try:
+            assert type(key) is int
+        except AssertionError:
+            raise TypeError  # index must be integer type
+        try:
+            assert key >= 0
+        except AssertionError:
+            raise IndexError  # index must be positive
+
+        node = self
+
+        while key > 0:
+            if node.variations:
+                node = node.variations[0]
+                key -= 1
+            else:
+                raise IndexError
+
+        return node
+
 
 class Game(GameNode):
     """

--- a/test.py
+++ b/test.py
@@ -2262,6 +2262,28 @@ class PgnTestCase(unittest.TestCase):
         result = len(first_game)
         self.assertEqual(result, 90)
 
+    def test_getitem(self):
+        with open("data/pgn/kasparov-deep-blue-1997.pgn") as pgn:
+            first_game = chess.pgn.read_game(pgn)
+
+        result = first_game[5].san()
+        self.assertEqual(result, 'b3')
+
+        result = first_game[0]
+        self.assertEqual(result, first_game.root())
+
+        # Out of bounds index must raise IndexError
+        with self.assertRaises(IndexError):
+            first_game[-1]
+        with self.assertRaises(IndexError):
+            first_game[500]
+
+        # Non-integer index must raise TypeError
+        with self.assertRaises(TypeError):
+            first_game['a']
+        with self.assertRaises(TypeError):
+            first_game[0.5]
+
 
 class CraftyTestCase(unittest.TestCase):
 

--- a/test.py
+++ b/test.py
@@ -2256,6 +2256,12 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(subgame.variations[0].move, chess.Move.from_uci("c2c4"))
         self.assertEqual(subgame.variations[1].move, chess.Move.from_uci("g1f3"))
 
+    def test_len(self):
+        with open("data/pgn/kasparov-deep-blue-1997.pgn") as pgn:
+            first_game = chess.pgn.read_game(pgn)
+        result = len(first_game)
+        self.assertEqual(result, 90)
+
 
 class CraftyTestCase(unittest.TestCase):
 

--- a/test.py
+++ b/test.py
@@ -26,7 +26,7 @@ import platform
 import sys
 import textwrap
 import threading
-import time
+import time  # noqa F401
 import unittest
 from io import StringIO
 
@@ -389,7 +389,7 @@ class BoardTestCase(unittest.TestCase):
         self.assertNotIn(chess.Move.from_uci("g1e1"), board.legal_moves)
         self.assertNotIn(chess.Move.from_uci("g1c1"), board.legal_moves)
         self.assertNotIn(chess.Move.from_uci("g1a1"), board.legal_moves)
-        self.assertIn(chess.Move.from_uci("g1h1"), board.legal_moves) # Kh1
+        self.assertIn(chess.Move.from_uci("g1h1"), board.legal_moves)  # Kh1
 
     def test_selective_castling(self):
         board = chess.Board("r3k2r/pppppppp/8/8/8/8/PPPPPPPP/R3K2R w KQkq - 0 1")
@@ -1424,7 +1424,7 @@ class LegalMoveGeneratorTestCase(unittest.TestCase):
 
         board = MockBoard()
         gen = chess.LegalMoveGenerator(board)
-        _ = list(gen)
+        _ = list(gen)  # noqa F841
         self.assertEqual(board.traversals, 1)
 
 
@@ -1695,8 +1695,7 @@ class PolyglotTestCase(unittest.TestCase):
             self.assertEqual(entry.move(), chess.Move.from_uci("c2c4"))
 
             # Weighted choice with excluded move.
-            entry = book.weighted_choice(chess.Board(),
-                exclude_moves=[chess.Move.from_uci("e2e4")], random=FirstMockRandom())
+            entry = book.weighted_choice(chess.Board(), exclude_moves=[chess.Move.from_uci("e2e4")], random=FirstMockRandom())
             self.assertEqual(entry.move(), chess.Move.from_uci("d2d4"))
 
     def test_find(self):
@@ -2315,9 +2314,9 @@ class CraftyTestCase(unittest.TestCase):
 
     def test_mate_search(self):
         board = chess.Board()
-        board.set_fen("4r1k1/pQ3pp1/7p/4q3/4r3/P7/1P2nPPP/2BR1R1K b - - 0 1") # Mate in 2
+        board.set_fen("4r1k1/pQ3pp1/7p/4q3/4r3/P7/1P2nPPP/2BR1R1K b - - 0 1")  # Mate in 2
         self.engine.setboard(board)
-        self.engine.sd(15) # Just to be safe
+        self.engine.sd(15)  # Just to be safe
         post_handler = chess.xboard.PostHandler()
         self.engine.post_handlers.append(post_handler)
         self.engine.go()
@@ -2328,7 +2327,7 @@ class CraftyTestCase(unittest.TestCase):
 
     def test_usermove(self):
         board = chess.Board()
-        board.set_fen("4r1k1/pQ3pp1/7p/4q3/4r3/P7/1P2nPPP/2BR1R1K b - - 0 1") # Mate in 2
+        board.set_fen("4r1k1/pQ3pp1/7p/4q3/4r3/P7/1P2nPPP/2BR1R1K b - - 0 1")  # Mate in 2
         self.engine.setboard(board)
         self.engine.usermove(chess.Move.from_uci("e5h2"))
         self.engine.usermove(chess.Move.from_uci("h1h2"))
@@ -2345,7 +2344,7 @@ class CraftyTestCase(unittest.TestCase):
 
     def test_playother(self):
         board = chess.Board()
-        board.set_fen("4r1k1/pQ3pp1/7p/4q3/4r3/P7/1P2nPPP/2BR1R1K b - - 0 1") # Mate in 2
+        board.set_fen("4r1k1/pQ3pp1/7p/4q3/4r3/P7/1P2nPPP/2BR1R1K b - - 0 1")  # Mate in 2
         self.engine.setboard(board)
         board.push(chess.Move.from_uci("e5h2"))
         self.engine.playother()
@@ -2494,18 +2493,17 @@ class XboardEngineTestCase(unittest.TestCase):
         self.mock = chess.engine.MockProcess(self.engine)
         self.mock.expect("xboard")
         feature_list = (
-                "feature egt=syzygy,gaviota",
-                "feature option=\"spinvar -spin 50 0 100\"",
-                "feature option=\"combovar -combo HI /// HELLO /// BYE\"",
-                "feature option=\"checkvar -check 0\"",
-                "feature option=\"stringvar -string \"\"\"",
-                "feature option=\"filevar -file \"\"\"",
-                "feature option=\"pathvar -path \"\"\"",
-                "feature option=\"buttonvar -button\"",
-                "feature option=\"resetvar -reset\"",
-                "feature option=\"savevar -save\"",
-
-                )
+            "feature egt=syzygy,gaviota",
+            "feature option=\"spinvar -spin 50 0 100\"",
+            "feature option=\"combovar -combo HI /// HELLO /// BYE\"",
+            "feature option=\"checkvar -check 0\"",
+            "feature option=\"stringvar -string \"\"\"",
+            "feature option=\"filevar -file \"\"\"",
+            "feature option=\"pathvar -path \"\"\"",
+            "feature option=\"buttonvar -button\"",
+            "feature option=\"resetvar -reset\"",
+            "feature option=\"savevar -save\"",
+        )
         self.mock.expect("protover 2", feature_list)
         self.mock.expect("post")
         self.mock.expect("easy")
@@ -2617,7 +2615,7 @@ class XboardEngineTestCase(unittest.TestCase):
     def test_resign_during_human_turn(self):
         self.mock.expect("nopost", ("resign", ))
         self.mock.expect("result 1-0")
-        self.engine.nopost() # Command to make MockProcess expect a random `resign`
+        self.engine.nopost()  # Command to make MockProcess expect a random `resign`
 
         # Set when handling "offer draw" from the engine.
         self.engine.move_received.wait()
@@ -3183,7 +3181,8 @@ class SyzygyTestCase(unittest.TestCase):
                 solution = board.set_epd(epd)
 
                 dtz = tables.probe_dtz(board)
-                self.assertAlmostEqual(dtz, solution["dtz"], delta=1, msg="Expected dtz {}, got {} (in l. {}, fen: {})".format(solution["dtz"], dtz, l + 1, board.fen()))
+                self.assertAlmostEqual(dtz, solution["dtz"], delta=1,
+                                       msg="Expected dtz {}, got {} (in l. {}, fen: {})".format(solution["dtz"], dtz, l + 1, board.fen()))
 
 
 class NativeGaviotaTestCase(unittest.TestCase):
@@ -3244,7 +3243,7 @@ class GaviotaTestCase(unittest.TestCase):
                     expected = extra["dm"] * 2
                 dtm = self.tablebase.probe_dtm(board)
                 self.assertEqual(dtm, expected,
-                    "Expecting dtm {} for {}, got {} (at line {})".format(expected, board.fen(), dtm, line + 1))
+                                 "Expecting dtm {} for {}, got {} (at line {})".format(expected, board.fen(), dtm, line + 1))
 
     @catchAndSkip(chess.gaviota.MissingTableError)
     def test_dm_5(self):
@@ -3265,7 +3264,7 @@ class GaviotaTestCase(unittest.TestCase):
                     expected = extra["dm"] * 2
                 dtm = self.tablebase.probe_dtm(board)
                 self.assertEqual(dtm, expected,
-                    "Expecting dtm {} for {}, got {} (at line {})".format(expected, board.fen(), dtm, line + 1))
+                                 "Expecting dtm {} for {}, got {} (at line {})".format(expected, board.fen(), dtm, line + 1))
 
     def test_wdl(self):
         board = chess.Board("8/8/4K3/2n5/8/3k4/8/8 w - - 0 1")

--- a/test.py
+++ b/test.py
@@ -2284,6 +2284,21 @@ class PgnTestCase(unittest.TestCase):
         with self.assertRaises(TypeError):
             first_game[0.5]
 
+    def test_reversed(self):
+        with open("data/pgn/kasparov-deep-blue-1997.pgn") as pgn:
+            first_game = chess.pgn.read_game(pgn)
+
+        reversed_game = reversed(first_game)
+
+        result = next(reversed_game)
+
+        self.assertEqual(result.san(), 'g7')
+        self.assertEqual(result, first_game.end())
+
+        with self.assertRaises(StopIteration):
+            while True:
+                next(reversed_game)
+
 
 class CraftyTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Closes #319 

I didn't see anything obvious to add this to except a GameNode. It looks like variations are just lists of moves so they are already iterators. Let me know if I missed something and I'll throw it in, now that I've worked out how to do this.

As mentioned in the `TODO` I added to the code, this doesn't support slices yet. I don't really need that in `python-chess-annotator` so I went ahead and submitted this as-is. If you're interested in that feature I can open a separate issue to get that together later.