### PR TITLE
Remove the TODO

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -3621,7 +3621,3 @@ class SquareSet(collections.abc.MutableSet):
         True
         """
         return cls(BB_SQUARES[square])
-
-
-# TODO: Deprecated
-BB_VOID = 0


### PR DESCRIPTION
Now that we have and use BB_EMPTY (instead of BB_VOID), we can safely remove this TODO tag.