### PR TITLE
Remove superfluous reference

### DIFF
--- a/fuzz/fen.py
+++ b/fuzz/fen.py
@@ -12,7 +12,7 @@ def fuzz(buf):
     else:
         try:
             board = chess.Board(fen)
-        except ValueError as err:
+        except ValueError:
             pass
         else:
             sanitized_fen = board.fen()


### PR DESCRIPTION
In the case of encountering the ValueError, we simply pass, so the reference ‘err’ is not needed at all. It’s superfluous.