### PR TITLE
Fix grammar

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -281,7 +281,7 @@ class Option(NamedTuple):
 
 
 class Limit:
-    """Search termination condition."""
+    """Searches termination condition."""
 
     def __init__(self, *,
                  time: Optional[float] = None,
@@ -360,7 +360,7 @@ class PlayResult:
 
 
 class Info(enum.IntFlag):
-    """Select information sent by the chess engine."""
+    """Selects information sent by the chess engine."""
     NONE = 0
     BASIC = 1
     SCORE = 2
@@ -386,15 +386,15 @@ class PovScore:
         self.turn = turn
 
     def white(self) -> "Score":
-        """Get the score from White's point of view."""
+        """Gets the score from White's point of view."""
         return self.pov(chess.WHITE)
 
     def black(self) -> "Score":
-        """Get the score from Black's point of view."""
+        """Gets the score from Black's point of view."""
         return self.pov(chess.BLACK)
 
     def pov(self, color: chess.Color) -> "Score":
-        """Get the score from the point of view of the given *color*."""
+        """Gets the score from the point of view of the given *color*."""
         return self.relative if self.turn == color else -self.relative
 
     def is_mate(self) -> bool:


### PR DESCRIPTION
These docstrings were fixed to accomodate to the wording style of other docstrings throughout python-chess. The documentation is therefore fixed.