### PR TITLE
Simplify release.py module

### DIFF
--- a/release.py
+++ b/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#! /usr/bin/env python3
 # Helper script to create and publish a new python-chess release.
 
 import os
@@ -20,9 +20,9 @@ def check_git():
     system("git diff --cached --exit-code")
 
     system("git fetch origin")
-    behind = subprocess.check_output(["git", "rev-list", "--count", "master..origin/master"])
-    if int(behind) > 0:
-        print(f"master is {int(behind)} commits behind origin/master")
+    behind = int(subprocess.check_output(["git", "rev-list", "--count", "master..origin/master"]))
+    if behind > 0:
+        print(f"master is {behind} commits behind origin/master")
         sys.exit(1)
 
 def test():


### PR DESCRIPTION
Call the int() function just once. Current code calls the int() function twice in the case  master is behind.

Furthermore, the shebang line is improved, visually and functionally. Calling ‘env’ is preffered. It ensures that the Python interpreter is found (by the Linux ‘env’ command) even if installed on some custom path. This shebang line needs to change in every module that exists for the python-chess project. I can make a PR for this.