### PR TITLE
Remove the obsolete first line

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-#
 # This file is part of the python-chess library.
 # Copyright (C) 2012-2020 Niklas Fiekas <niklas.fiekas@backscattering.de>
 #


### PR DESCRIPTION
Now that python-chess supports only Python 3.6+ (for some time
now), we don’t need this first line anymore. Python 3 does not need
this line because UTF-8 is universal. In any other module in the python-chess project it
is obsolete. I am removing it in this module. Other modules should follow suit.