### PR TITLE
Add new constant BOARD_SIZE

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -26,6 +26,7 @@ import xml.etree.ElementTree as ET
 from typing import Iterable, Optional, Tuple, Union
 
 
+BOARD_SIZE = 400
 SQUARE_SIZE = 45
 MARGIN = 20
 


### PR DESCRIPTION
Added the BOARD_SIZE constant. It may come handy and save one line of code.

Example from my code:

MY_CUSTOM_BOARD_SIZE = 800
COORDINATES = True
MY_CUSTOM_MARGIN = (chess.svg.MARGIN  # This MARGIN constant is already very handy.
                                             * MY_CUSTOM_BOARD_SIZE  # The non-default size of the board set by the programmer.
                                             / chess.svg.BOARD_SIZE  # Can be used like this from now on, saving one line of code.
                                             if COORDINATES
                                             else 0)

Also, if one wants to set a board size limit to 400x400, he/she can just pass chess.svg.BOARD_SIZE to the 'size' argument of chess.svg.board(), like this:
chess.svg.board(..., size=chess.svg.BOARD_SIZE)

I think 400 is the most reasonable number as a board size limit.