### PR TITLE
Bad Sphinx rendering

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -7,7 +7,7 @@ Colors
 Constants for the side to move or the color of a piece.
 
 .. py:data:: chess.WHITE
-    :annotation: = True
+    :annotation:  = True
 
 .. py:data:: chess.BLACK
     :annotation: = False


### PR DESCRIPTION
This Sphinx code
.. py:data:: chess.WHITE
    :annotation: = True
is rendered as
chess.WHITE= True
if you look closely (there’s no space in front of the equal sign, separating ‘E’ and the equal sign.

Can this be fixed or is this not doable? Discard this PR if you find this not solvable.