### PR TITLE
"Seven Tag Roster", and not "7 tag roster"

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -527,7 +527,7 @@ class Game(GameNode):
 
     @classmethod
     def without_tag_roster(cls: Type[GameT]) -> GameT:
-        """Creates an empty game without the default 7 tag roster."""
+        """Creates an empty game without the Seven Tag Roster."""
         return cls(headers={})
 
     @classmethod


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Portable_Game_Notation#Tag_pairs) and also Chess.com and other credible sites, the seven PGN tag pairs are reffered to and written as the **Seven Tag Roster**, or STR for short, and not as **7 tag roster** (as in the pgn.py module). Also, you can't speak of the STR as being default. STR is just STR. So I am fixing this, which will fix the documentation text.