### PR TITLE
Simplify unittest.skipIf() decorator condition

### DIFF
--- a/test.py
+++ b/test.py
@@ -2591,7 +2591,7 @@ class PgnTestCase(unittest.TestCase):
         self.assertTrue(isinstance(node, MyGameNode))
 
 
-@unittest.skipIf(sys.platform == "win32" and (3, 8, 0) <= sys.version_info < (3, 8, 1), "https://bugs.python.org/issue34679")
+@unittest.skipIf(platform.system() == "Windows" and platform.python_version() < "3.8.1", "https://bugs.python.org/issue34679")
 class EngineTestCase(unittest.TestCase):
 
     def test_uci_option_map_equality(self):


### PR DESCRIPTION
This change provides the same result, but it is more readable. Also, someone on StackOverflow ensured that checking for the OS version is more reliable by using platform.system(): https://stackoverflow.com/questions/1854/what-os-am-i-running-on/58071295#58071295

Furthermore, the current Python version comparison is the same now and not complicated. It's simpler to compare the Python version as being less than version 3.8.1 as opposed to less than or equal to 3.8.0 and less than 3.8.1.