### PR TITLE
Fix one character

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -101,7 +101,7 @@ Moves
 
     .. py:attribute:: promotion
 
-        The promotion piece type or ``Ǹone``.
+        The promotion piece type or ``None``.
 
     .. py:attribute:: drop
 


### PR DESCRIPTION
There's this strange character that is lurking in the documentation. At first, I thought my screen was dirty.