### PR TITLE
Fix tox script

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,pypy3
+envlist = py36,py37,py38,pypy3
 
 [testenv]
 passenv = LD_LIBRARY_PATH
@@ -12,9 +12,9 @@ commands =
 
 [flake8]
 ignore =
-    E126 E131 # allow over indent and unaligned indent
-    E241 # allow indenting array elements
-    E302 E305 # allow grouping functions
-    E741 # allow "ambiguous" variable names
-    W504 # allow binary operators before eol
+    E126 E131  # Allow overindent and unaligned indent
+    E241  # Allow indenting array elements
+    E302 E305  # Allow grouping functions
+    E741  # Allow "ambiguous" variable names
+    W504  # Allow binary operators before end-of-line (EOL)
 max-line-length = 160


### PR DESCRIPTION
Removed ‘py35’ from ‘envlist’ since we don’t  support Python 3.5 anymore. Plus other fixes.