### PR TITLE
Carry-Rippler?!

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -322,8 +322,8 @@ def _edges(square: Square) -> Bitboard:
     return (((BB_RANK_1 | BB_RANK_8) & ~BB_RANKS[square_rank(square)]) |
             ((BB_FILE_A | BB_FILE_H) & ~BB_FILES[square_file(square)]))
 
-def _carry_rippler(mask: Bitboard) -> Iterator[Bitboard]:
-    # Carry-Rippler trick to iterate subsets of mask.
+def _ripple_carry(mask: Bitboard) -> Iterator[Bitboard]:
+    # Ripple-carry trick to iterate subsets of a mask.
     subset = BB_EMPTY
     while True:
         yield subset
@@ -339,7 +339,7 @@ def _attack_table(deltas: List[int]) -> Tuple[List[Bitboard], List[Dict[Bitboard
         attacks = {}
 
         mask = _sliding_attacks(square, 0, deltas) & ~_edges(square)
-        for subset in _carry_rippler(mask):
+        for subset in _ripple_carry(mask):
             attacks[subset] = _sliding_attacks(square, subset, deltas)
 
         attack_table.append(attacks)
@@ -3735,9 +3735,9 @@ class SquareSet:
 
     # SquareSet
 
-    def carry_rippler(self) -> Iterator[Bitboard]:
+    def ripple_carry(self) -> Iterator[Bitboard]:
         """Iterator over the subsets of this set."""
-        return _carry_rippler(self.mask)
+        return _ripple_carry(self.mask)
 
     def mirror(self) -> "SquareSet":
         """Returns a vertically mirrored copy of this square set."""

--- a/test.py
+++ b/test.py
@@ -1760,9 +1760,9 @@ class SquareSetTestCase(unittest.TestCase):
         self.assertEqual(chess.SquareSet.from_square(chess.H5), chess.BB_H5)
         self.assertEqual(chess.SquareSet.from_square(chess.C2), chess.BB_C2)
 
-    def test_carry_rippler(self):
-        self.assertEqual(sum(1 for _ in chess.SquareSet(chess.BB_D1).carry_rippler()), 2 ** 1)
-        self.assertEqual(sum(1 for _ in chess.SquareSet(chess.BB_FILE_B).carry_rippler()), 2 ** 8)
+    def test_ripple_carry(self):
+        self.assertEqual(sum(1 for _ in chess.SquareSet(chess.BB_D1).ripple_carry()), 2 ** 1)
+        self.assertEqual(sum(1 for _ in chess.SquareSet(chess.BB_FILE_B).ripple_carry()), 2 ** 8)
 
     def test_mirror(self):
         self.assertEqual(chess.SquareSet(0x00a2_0900_0004_a600).mirror(), 0x00a6_0400_0009_a200)


### PR DESCRIPTION
Fixed the code and tests for the wrongly named _carry_rippler() function. It is _ripple_carry() now. In electronics, there is the ripple-carry adder. Carry-Ripler does not exist anywhere. I don't know who named this function like that. Anyway, it is fixed now.

Would be a good idea to notify about this function rename in the changelog (if the pull request is merged).