### PR TITLE
Maybe we missed this one?

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -3790,7 +3790,7 @@ class SquareSet:
 
         for square in SQUARES_180:
             mask = BB_SQUARES[square]
-            builder.append("1" if self.mask & mask else ".")
+            builder.append("1" if self.mask & mask else "·")
 
             if not mask & BB_FILE_H:
                 builder.append(" ")


### PR DESCRIPTION
When we changed the interpoint to a circle, we may have missed this one. Not related to the unicode() method, but still.

This was a normal period character. Now I changed it to an interpoint, because I don't think the circle character applies here. Or does it? @niklasf, please check it out.