### PR TITLE
Prettify the clear_stack() function

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1451,8 +1451,8 @@ class Board(BaseBoard):
 
     def clear_stack(self) -> None:
         """Clears the move stack."""
-        del self.move_stack[:]
-        del self._stack[:]
+        self.move_stack.clear()
+        self._stack.clear()
 
     def root(self: BoardT) -> BoardT:
         """Returns a copy of the root position."""


### PR DESCRIPTION
Since Python 3.3, there is a new method for the list type, named clear(). And since we don’t support Python 2 anymore, we can prettify the codebase with this much-better-looking syntax.