### PR TITLE
Add a GET_INDEX dictionary

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -123,6 +123,7 @@ SQUARES = [
 ] = range(64)
 
 SQUARE_NAMES = [f + r for r in RANK_NAMES for f in FILE_NAMES]
+GET_INDEX = {square_name: index for (index, square_name) in enumerate(SQUARE_NAMES)}
 
 def square(file_index: int, rank_index: int) -> Square:
     """Gets a square number by file and rank index."""


### PR DESCRIPTION
It is intended to be used like this:
chess.Move(GET_INDEX["e2"], GET_INDEX["e4"])

In some situations, it may be convenient to have a GET_INDEX dictionary if the programmer is getting square data in string form (str type) and wants to pass that directly into chess.Move(). And since chess.Move() accepts only indexes (int type), this could be a convenient feature.

I couldn't think of a better name for this. Maybe GET_INDEX is not so good as a name. Maybe just INDEX? It's shorter. I don't know.