### PR TITLE
Fix default value from () to []

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -146,7 +146,7 @@ def board(board: Optional[chess.BaseBoard] = None, *,
           coordinates: bool = True,
           lastmove: Optional[chess.Move] = None,
           check: Optional[chess.Square] = None,
-          arrows: Iterable[Union[Arrow, Tuple[chess.Square, chess.Square]]] = (),
+          arrows: Iterable[Union[Arrow, Tuple[chess.Square, chess.Square]]] = [],
           size: Optional[int] = None,
           style: Optional[str] = None) -> str:
     """


### PR DESCRIPTION
The default value of the `arrows` argument of the `chess.svg.board()` function can not be an empty tuple, it must be an empty list, since the `arrows` argument accepts a **list of tuples**. So, I think, we should fix that.