### PR TITLE
Added clock_comment method to the GameNode class

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -106,6 +106,8 @@ MOVETEXT_REGEX = re.compile(r"""
 
 SKIP_MOVETEXT_REGEX = re.compile(r""";|\{|\}""")
 
+CLOCK_REGEX = re.compile("\[%clk\s([^\]]*)\]") # used by the clock_comment method of GameNode
+
 TAG_ROSTER = ["Event", "Site", "Date", "Round", "White", "Black", "Result"]
 
 
@@ -463,11 +465,11 @@ class GameNode:
       Searches the comment string for a substring of the form [%clk <<clock string>>>] and
       returns <<clock string>>, or returns the empty string if no such substring is found.
       """
-      CLOCK_REGEX = re.compile("\[%clk\s([^\]]*)\]")
-      try:
-        return re.search(CLOCK_REGEX, self.comment).groups()[0]
-      except:
+      match = re.search(CLOCK_REGEX, self.comment)
+      if match is None:
         return ""
+      else:
+        return match.groups()[0]
 
     def __str__(self) -> str:
         return self.accept(StringExporter(columns=None))

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -458,6 +458,17 @@ class GameNode:
         visitor.end_game()
         return visitor.result()
 
+    def clock_comment(self) -> str:
+      """
+      Searches the comment string for a substring of the form [%clk <<clock string>>>] and
+      returns <<clock string>>, or returns the empty string if no such substring is found.
+      """
+      CLOCK_REGEX = re.compile("\[%clk\s([^\]]*)\]")
+      try:
+        return re.search(CLOCK_REGEX, self.comment).groups()[0]
+      except:
+        return ""
+
     def __str__(self) -> str:
         return self.accept(StringExporter(columns=None))
 


### PR DESCRIPTION
I hope that I've created this pull request in the proper way! :)

There are other ways to accomplish what we want, i.e., allowing access to timestamps. We could have a more general method that returns a dict whose keys are commands (from https://www.enpassant.dk/chess/palview/enhancedpgn.htm) and whose corresponding values are the corresponding parameters. The method defined in this PR simply searches a node's comment for the "clk" command in particular and returns its parameter as a string (or "" if the "clk" comment is not present), which seems like the simplest and least opinionated way to make timestamps available. However, I am not attached to this particular way of doing it and I'm open to feedback if we want to do it differently.