### PR TITLE
Fix in-line comments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,10 @@ commands =
 
 [flake8]
 ignore =
-    E126 E131 # allow over indent and unaligned indent
-    E241 # allow indenting array elements
-    E302 E305 # allow grouping functions
-    E741 # allow "ambiguous" variable names
-    W504 # allow binary operators before eol
-    E704 E301 # allow "def overloaded(): ..."
+    E126 E131  # Allow over-indent and unaligned indent
+    E241  # Allow indenting array elements
+    E302 E305  # Allow grouping functions
+    E741  # Allow "ambiguous" variable names
+    W504  # Allow binary operators before EOL (end of line)
+    E704 E301  # Allow "def overloaded(): ..."
 max-line-length = 160


### PR DESCRIPTION
All in-line comments should be separated by 2 empty spaces and started with a capital letter. Fixed that. Also, 2 more things were fixed: "over indent" to "over-indent" and "eol" to "EOL (end of line)".