### PR TITLE
Fix push_san() docstring

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2829,7 +2829,7 @@ class Board(BaseBoard):
     def push_san(self, san: str) -> Move:
         """
         Parses a move in standard algebraic notation, makes the move and puts
-        it on the the move stack.
+        it onto the move stack.
 
         Returns the move.
 


### PR DESCRIPTION
Fixed a typo where it says "on the the", clearly an overlook from 5 years ago. The correct wording is "onto the", talking about a move stack. As stated on GrammarBook.com: In general, use "onto" as one word to mean “on top of,” “to a position on,” “upon.” And since we push moves "on top of" the stack, I fixed the wording accordingly.