### PR TITLE
Improve chess.svg.board() docstring

### DIFF
--- a/chess/svg.py
+++ b/chess/svg.py
@@ -198,7 +198,8 @@ def board(board: Optional[chess.BaseBoard] = None, *,
         ``square light``, ``square dark``, ``square light lastmove``,
         ``square dark lastmove``, ``margin``, ``coord``, ``arrow green``,
         ``arrow blue``, ``arrow red``, and ``arrow yellow``. Values should look
-        like ``#ffce9e`` (opaque) or ``#15781B80`` (transparent).
+        like ``#ffce9e`` (opaque) or ``#15781B80`` (transparent). The values can
+        also look like color names, like ``red``, ``green``, ``blue``, etc.
     :param style: A CSS stylesheet to include in the SVG image.
 
     >>> import chess


### PR DESCRIPTION
Explain that regular color names like `red`, `green`, `blue`, and the like, can also be passed in as `color` arguments to `chess.svg.board()`.