### PR TITLE
Allow zeros in SAN castling notation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,40 @@
 Changelog for python-chess
 ==========================
 
+New in v1.0.0
+-------------
+
+Changes:
+
+* Now requires Python 3.7+.
+* `chess.engine` will now cut off illegal principal variations at the first
+  illegal move instead of discarding them entirely.
+* `chess.engine.EngineProtocol` renamed to `chess.engine.Protocol`.
+* `chess.engne.Option` is no longer a named tuple.
+* Renamed `chess.gaviota` internals.
+* Relaxed type annotations of `chess.pgn.GameNode.variation()` and related
+  methods.
+* Documentation improvements. Will now show type aliases like `chess.Square`
+  instead of `int`.
+
+Bugfixes:
+
+* Fix insufficient material with same-color bishops on both sides.
+* Clarify that `chess.Board.can_claim_draw()` and related methods refer to
+  claims by the player to move. Three-fold repetition could already be claimed
+  before making the final repeating move. `chess.Board.can_claim_fifty_moves()`
+  now also allows a claim before the final repeating move. The previous
+  behavior is `chess.Board.is_fifty_moves()`.
+* Fix parsing of green arrows/circles in `chess.pgn.GameNode.arrows()`.
+* Fix overloaded type signature of `chess.engine.Protocol.engine()`.
+
+New features:
+
+* Added `chess.parse_square()`, to be used instead of
+  `chess.SQUARE_NAMES.index()`.
+* Added `chess.Board.apply_mirror()`.
+* Added `chess.svg.board(..., colors)`, to allow overriding the default theme.
+
 New in v0.31.4
 --------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog for python-chess
 ==========================
 
+New in v1.0.1
+-------------
+
+Bugfixes:
+
+* `chess.svg`: Restore SVG Tiny compatibility by splitting colors like
+  `#rrggbbaa` into a solid color and opacity.
+
 New in v1.0.0
 -------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Changes:
 * `chess.engine` will now cut off illegal principal variations at the first
   illegal move instead of discarding them entirely.
 * `chess.engine.EngineProtocol` renamed to `chess.engine.Protocol`.
-* `chess.engne.Option` is no longer a named tuple.
+* `chess.engine.Option` is no longer a named tuple.
 * Renamed `chess.gaviota` internals.
 * Relaxed type annotations of `chess.pgn.GameNode.variation()` and related
   methods.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,9 @@ Changes:
 * Renamed `chess.gaviota` internals.
 * Relaxed type annotations of `chess.pgn.GameNode.variation()` and related
   methods.
+* Changed default colors of `chess.svg.Arrow` and
+  `chess.pgn.GameNode.arrows()`. These can be overriden with the new
+  `chess.svg.board(..., colors)` feature.
 * Documentation improvements. Will now show type aliases like `chess.Square`
   instead of `int`.
 

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -26,7 +26,7 @@ __author__ = "Niklas Fiekas"
 
 __email__ = "niklas.fiekas@backscattering.de"
 
-__version__ = "0.31.4"
+__version__ = "1.0.0"
 
 import collections
 import copy

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2802,6 +2802,7 @@ class Board(BaseBoard):
         """
         # Castling.
         try:
+            san = san.replace('0', 'O')
             if san in ["O-O", "O-O+", "O-O#"]:
                 return next(move for move in self.generate_castling_moves() if self.is_kingside_castling(move))
             elif san in ["O-O-O", "O-O-O+", "O-O-O#"]:

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1828,7 +1828,7 @@ class Board(BaseBoard):
         #     pawns or knights. These would allow selfmate.
         if self.occupied_co[color] & self.bishops:
             same_color = (not self.bishops & BB_DARK_SQUARES) or (not self.bishops & BB_LIGHT_SQUARES)
-            return same_color and not (self.occupied_co[not color] & ~self.kings & ~self.rooks & ~self.queens)
+            return same_color and not self.pawns and not self.knights
 
         return True
 

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -26,7 +26,7 @@ __author__ = "Niklas Fiekas"
 
 __email__ = "niklas.fiekas@backscattering.de"
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 import collections
 import copy

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -34,10 +34,11 @@ import typing
 import os
 import re
 
+import chess
+
 from types import TracebackType
 from typing import Any, Callable, Coroutine, Deque, Dict, Generator, Generic, Iterable, Iterator, List, Mapping, MutableMapping, Optional, Tuple, Type, TypeVar, Union
-
-import chess
+from chess import Color
 
 
 T = TypeVar("T")
@@ -340,7 +341,7 @@ INFO_ALL = Info.ALL
 class PovScore:
     """A relative :class:`~chess.engine.Score` and the point of view."""
 
-    def __init__(self, relative: Score, turn: chess.Color) -> None:
+    def __init__(self, relative: Score, turn: Color) -> None:
         self.relative = relative
         self.turn = turn
 
@@ -352,7 +353,7 @@ class PovScore:
         """Gets the score from Black's point of view."""
         return self.pov(chess.BLACK)
 
-    def pov(self, color: chess.Color) -> Score:
+    def pov(self, color: Color) -> Score:
         """Gets the score from the point of view of the given *color*."""
         return self.relative if self.turn == color else -self.relative
 

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -111,23 +111,23 @@ class EventLoopPolicy(asyncio.AbstractEventLoopPolicy):
 
         try:
             os.close(os.pidfd_open(os.getpid()))  # type: ignore
-            return asyncio.PidfdChildWatcher()  # type: ignore
+            watcher: asyncio.AbstractChildWatcher = asyncio.PidfdChildWatcher()  # type: ignore
+            LOGGER.debug("Using PidfdChildWatcher")
+            return watcher
         except (AttributeError, OSError):
             # Before Python 3.9 or before Linux 5.3 or the syscall is not
             # permitted.
             pass
-        else:
-            LOGGER.debug("Using PidfdChildWatcher")
 
         if threading.current_thread() is threading.main_thread():
             try:
-                return asyncio.ThreadedChildWatcher()
+                watcher = asyncio.ThreadedChildWatcher()
+                LOGGER.debug("Using ThreadedChildWatcher")
+                return watcher
             except AttributeError:
                 # Before Python 3.8.
                 LOGGER.debug("Using SafeChildWatcher")
                 return asyncio.SafeChildWatcher()
-            else:
-                LOGGER.debug("Using ThreadedChildWatcher")
 
         class PollingChildWatcher(asyncio.SafeChildWatcher):
             _loop: Optional[asyncio.AbstractEventLoop]

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -879,8 +879,6 @@ class Protocol(asyncio.SubprocessProtocol, metaclass=abc.ABCMeta):
 
         return await asyncio.get_running_loop().subprocess_exec(cls, *command, **popen_args)  # type: ignore
 
-EngineProtocol = Protocol  # TODO: Remove before 1.0
-
 
 class CommandState(enum.Enum):
     New = 1

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -441,7 +441,7 @@ class GameNode:
         arrows = []
         for match in ARROWS_REGEX.finditer(self.comment):
             for group in match.group(1).split(","):
-                color = "G"
+                color = "green"
                 if group[0] == "R":
                     color = "red"
                 elif group[0] == "Y":

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -29,6 +29,7 @@ import chess.engine
 import chess.svg
 
 from typing import Any, Callable, Dict, Generic, Iterable, Iterator, List, Mapping, MutableMapping, Set, TextIO, Tuple, Type, TypeVar, Optional, Union
+from chess import Square
 
 
 LOGGER = logging.getLogger(__name__)
@@ -458,7 +459,7 @@ class GameNode:
 
         return arrows
 
-    def set_arrows(self, arrows: Iterable[Union[chess.svg.Arrow, Tuple[chess.Square, chess.Square]]]) -> None:
+    def set_arrows(self, arrows: Iterable[Union[chess.svg.Arrow, Tuple[Square, Square]]]) -> None:
         """
         Replaces all valid ``[%csl ...]`` and ``[%cal ...]`` annotations in
         the comment of this node or adds new ones.

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -77,13 +77,17 @@ DEFAULT_COLORS = {
     "square light lastmove": "#cdd16a",
     "margin": "#212121",
     "coord": "#e5e5e5",
+    "arrow green": "#15781B80",
+    "arrow red": "#88202080",
+    "arrow yellow": "#e68f00b3",
+    "arrow blue": "#00308880",
 }
 
 
 class Arrow:
     """Details of an arrow to be drawn."""
 
-    def __init__(self, tail: Square, head: Square, *, color: str = "#888") -> None:
+    def __init__(self, tail: Square, head: Square, *, color: str = "green") -> None:
         self.tail = tail
         self.head = head
         self.color = color
@@ -288,7 +292,12 @@ def board(board: Optional[chess.BaseBoard] = None, *,
             tail, head, color = arrow.tail, arrow.head, arrow.color  # type: ignore
         except AttributeError:
             tail, head = arrow  # type: ignore
-            color = "#888"
+            color = "green"
+
+        try:
+            color = _color(colors, " ".join(["arrow", color]))
+        except KeyError:
+            pass
 
         tail_file = chess.square_file(tail)
         tail_rank = chess.square_rank(tail)
@@ -308,7 +317,6 @@ def board(board: Optional[chess.BaseBoard] = None, *,
                 "stroke-width": str(SQUARE_SIZE * 0.1),
                 "stroke": color,
                 "fill": "none",
-                "opacity": "0.5",
                 "class": "circle",
             })
         else:
@@ -331,7 +339,6 @@ def board(board: Optional[chess.BaseBoard] = None, *,
                 "y2": str(shaft_y),
                 "stroke": color,
                 "stroke-width": str(SQUARE_SIZE * 0.2),
-                "opacity": "0.5",
                 "stroke-linecap": "butt",
                 "class": "arrow",
             })
@@ -345,7 +352,6 @@ def board(board: Optional[chess.BaseBoard] = None, *,
             ET.SubElement(svg, "polygon", {
                 "points": " ".join(str(x) + "," + str(y) for x, y in marker),
                 "fill": color,
-                "opacity": "0.5",
                 "class": "arrow",
             })
 

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -129,7 +129,7 @@ def _color(colors: Dict[str, str], color: str) -> Tuple[str, float]:
             elif len(color) == 9:
                 return color[:7], int(color[7:], 16) / 0xff
         except ValueError:
-            pass  # Ignore invalid hex.
+            pass  # Ignore invalid hex value
     return color, 1.0
 
 

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -182,8 +182,9 @@ def board(board: Optional[chess.BaseBoard] = None, *,
         400 board) or ``None`` (the default) for no size limit.
     :param colors: Dictionary to override default colors. Possible keys are
         ``square light``, ``square dark``, ``square light lastmove``,
-        ``square dark lastmove``, ``margin``, and ``coord``. Values should look
-        like ``#ffce9e``.
+        ``square dark lastmove``, ``margin``, ``coord``, ``arrow green``,
+        ``arrow blue``, ``arrow red``, and ``arrow yellow``. Values should look
+        like ``#ffce9e`` (opaque) or ``#15781B80`` (transparent).
     :param style: A CSS stylesheet to include in the SVG image.
 
     >>> import chess

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -180,7 +180,7 @@ def board(board: Optional[chess.BaseBoard] = None, *,
         square is drawn as a circle, like ``[(chess.E2, chess.E2)]``.
     :param size: The size of the image in pixels (e.g., ``400`` for a 400 by
         400 board) or ``None`` (the default) for no size limit.
-    :param colors: Dictionary to override default colors. Possible keys are
+    :param colors: A dictionary to override default colors. Possible keys are
         ``square light``, ``square dark``, ``square light lastmove``,
         ``square dark lastmove``, ``margin``, ``coord``, ``arrow green``,
         ``arrow blue``, ``arrow red``, and ``arrow yellow``. Values should look

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -295,7 +295,7 @@ def board(board: Optional[chess.BaseBoard] = None, *,
             }))
 
     if coordinates:
-        coord_color, coord_opacity = _color(colors, "coord")  # TODO
+        coord_color, coord_opacity = _color(colors, "coord")
         for file_index, file_name in enumerate(chess.FILE_NAMES):
             x = (file_index if not flipped else 7 - file_index) * SQUARE_SIZE + margin
             svg.append(_coord(file_name, x, 0, SQUARE_SIZE, margin, True, margin, color=coord_color, opacity=coord_opacity))

--- a/chess/svg.py
+++ b/chess/svg.py
@@ -20,12 +20,13 @@
 
 from __future__ import annotations
 
-import chess
 import math
-
 import xml.etree.ElementTree as ET
 
+import chess
+
 from typing import Iterable, Optional, Tuple, Union
+from chess import IntoSquareSet, Square
 
 
 SQUARE_SIZE = 45
@@ -82,7 +83,7 @@ DEFAULT_COLORS = {
 class Arrow:
     """Details of an arrow to be drawn."""
 
-    def __init__(self, tail: chess.Square, head: chess.Square, *, color: str = "#888") -> None:
+    def __init__(self, tail: Square, head: Square, *, color: str = "#888") -> None:
         self.tail = tail
         self.head = head
         self.color = color
@@ -146,12 +147,12 @@ def piece(piece: chess.Piece, size: Optional[int] = None) -> str:
 
 
 def board(board: Optional[chess.BaseBoard] = None, *,
-          squares: Optional[chess.IntoSquareSet] = None,
+          squares: Optional[IntoSquareSet] = None,
           flipped: bool = False,
           coordinates: bool = True,
           lastmove: Optional[chess.Move] = None,
-          check: Optional[chess.Square] = None,
-          arrows: Iterable[Union[Arrow, Tuple[chess.Square, chess.Square]]] = [],
+          check: Optional[Square] = None,
+          arrows: Iterable[Union[Arrow, Tuple[Square, Square]]] = [],
           size: Optional[int] = None,
           style: Optional[str] = None) -> str:
     """

--- a/chess/syzygy.py
+++ b/chess/syzygy.py
@@ -380,9 +380,6 @@ def is_tablename(name: str, *, one_king: bool = True, piece_count: Optional[int]
         (not normalized or normalize_tablename(name) == name) and
         (not one_king or (name != "KvK" and name.startswith("K") and "vK" in name)))
 
-def is_table_name(name: str) -> bool:  # TODO: Remove before 1.0
-    return is_tablename(name, one_king=False)
-
 
 def tablenames(*, one_king: bool = True, piece_count: int = 6) -> Iterator[str]:
     first = "K" if one_king else "P"

--- a/chess/variant.py
+++ b/chess/variant.py
@@ -700,10 +700,8 @@ class CrazyhouseBoard(chess.Board):
         else:
             self.pockets[self.turn].add(piece_type)
 
-    def can_claim_fifty_moves(self) -> bool:
-        return False
-
-    def is_seventyfive_moves(self) -> bool:
+    def _is_halfmoves(self, n: int) -> bool:
+        # No draw by 50-move rule or 75-move rule.
         return False
 
     def is_irreversible(self, move: chess.Move) -> bool:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,20 @@
 import sys
 import os
+import typing
+
+# Do not resolve some type aliases.
+# See https://github.com/sphinx-doc/sphinx/issues/6518.
+_get_type_hints = typing.get_type_hints
+def get_type_hints(obj, globalns=None, localns=None):
+    if localns is None:
+        localns = {}
+    localns["Square"] = "chess.Square"
+    localns["Color"] = "chess.Color"
+    localns["PieceType"] = "chess.PieceType"
+    localns["Bitboard"] = "chess.Bitboard"
+    localns["IntoSquareSet"] = "chess.IntoSquareSet"
+    return _get_type_hints(obj, globalns, localns)
+typing.get_type_hints = get_type_hints
 
 # Import the chess module.
 sys.path.insert(0, os.path.abspath('..'))

--- a/docs/svg.rst
+++ b/docs/svg.rst
@@ -25,6 +25,6 @@ licensed under the GFDL, BSD and GPL.
         End square of the arrow.
 
     .. py:attribute:: color
-        :value: '#888'
+        :value: 'green'
 
         Arrow color.

--- a/test.py
+++ b/test.py
@@ -2793,7 +2793,7 @@ class EngineTestCase(unittest.TestCase):
     def test_sf_analysis(self):
         with chess.engine.SimpleEngine.popen_uci("stockfish", debug=True) as engine:
             board = chess.Board("8/6K1/1p1B1RB1/8/2Q5/2n1kP1N/3b4/4n3 w - - 0 1")
-            limit = chess.engine.Limit(depth=25)
+            limit = chess.engine.Limit(depth=26)
             analysis = engine.analysis(board, limit)
             with analysis:
                 for info in iter(analysis.next, None):

--- a/test.py
+++ b/test.py
@@ -2676,8 +2676,11 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(game.arrows(), [])
         game.set_arrows([(chess.A1, chess.A1), chess.svg.Arrow(chess.A1, chess.H1, color="red"), chess.svg.Arrow(chess.B1, chess.B8)])
         self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%eval #1]")
-        self.assertEqual(len(game.arrows()), 3)
-        self.assertTrue(any(arrow.color == "red" for arrow in game.arrows()))
+        arrows = game.arrows()
+        self.assertEqual(len(arrows), 3)
+        self.assertEqual(arrows[0].color, "green")
+        self.assertEqual(arrows[1].color, "red")
+        self.assertEqual(arrows[2].color, "green")
 
         game.set_clock(None)
         game.set_eval(None)

--- a/test.py
+++ b/test.py
@@ -524,6 +524,8 @@ class BoardTestCase(unittest.TestCase):
         _check(chess.Board("8/4bk2/8/8/8/8/3KB3/8 w - - 0 1"), False, False)
         _check(chess.Board("8/8/3Q4/2bK4/B7/8/1k6/8 w - - 1 68"), False, False)
         _check(chess.Board("8/5k2/8/8/8/4B3/3K1B2/8 w - - 0 1"), True, True)
+        _check(chess.Board("5K2/8/8/1B6/8/k7/6b1/8 w - - 0 39"), True, True)
+        _check(chess.Board("8/8/8/4k3/5b2/3K4/8/2B5 w - - 0 33"), True, True)
 
         _check(chess.variant.AtomicBoard("8/3k4/8/8/2N5/8/3K4/8 b - - 0 1"), True, True)
         _check(chess.variant.AtomicBoard("8/4rk2/8/8/8/8/3K4/8 w - - 0 1"), True, True)

--- a/test.py
+++ b/test.py
@@ -1268,20 +1268,27 @@ class BoardTestCase(unittest.TestCase):
     def test_fifty_moves(self):
         # Test positions from Jan Timman vs. Christopher Lutz (1995).
         board = chess.Board()
+        self.assertFalse(board.is_fifty_moves())
         self.assertFalse(board.can_claim_fifty_moves())
         board = chess.Board("8/5R2/8/r2KB3/6k1/8/8/8 w - - 19 79")
+        self.assertFalse(board.is_fifty_moves())
         self.assertFalse(board.can_claim_fifty_moves())
         board = chess.Board("8/8/6r1/4B3/8/4K2k/5R2/8 b - - 68 103")
+        self.assertFalse(board.is_fifty_moves())
         self.assertFalse(board.can_claim_fifty_moves())
         board = chess.Board("6R1/7k/8/8/1r3B2/5K2/8/8 w - - 99 119")
-        self.assertFalse(board.can_claim_fifty_moves())
+        self.assertFalse(board.is_fifty_moves())
+        self.assertTrue(board.can_claim_fifty_moves())
         board = chess.Board("8/7k/8/6R1/1r3B2/5K2/8/8 b - - 100 119")
+        self.assertTrue(board.is_fifty_moves())
         self.assertTrue(board.can_claim_fifty_moves())
         board = chess.Board("8/7k/8/1r3KR1/5B2/8/8/8 w - - 105 122")
+        self.assertTrue(board.is_fifty_moves())
         self.assertTrue(board.can_claim_fifty_moves())
 
         # Once checkmated, it is too late to claim.
         board = chess.Board("k7/8/NKB5/8/8/8/8/8 b - - 105 176")
+        self.assertFalse(board.is_fifty_moves())
         self.assertFalse(board.can_claim_fifty_moves())
 
         # A stalemate is a draw, but you can not and do not need to claim it by
@@ -1289,6 +1296,7 @@ class BoardTestCase(unittest.TestCase):
         board = chess.Board("k7/3N4/1K6/1B6/8/8/8/8 b - - 99 1")
         self.assertTrue(board.is_stalemate())
         self.assertTrue(board.is_game_over())
+        self.assertFalse(board.is_fifty_moves())
         self.assertFalse(board.can_claim_fifty_moves())
         self.assertFalse(board.can_claim_draw())
 

--- a/test.py
+++ b/test.py
@@ -526,6 +526,7 @@ class BoardTestCase(unittest.TestCase):
         _check(chess.Board("8/5k2/8/8/8/4B3/3K1B2/8 w - - 0 1"), True, True)
         _check(chess.Board("5K2/8/8/1B6/8/k7/6b1/8 w - - 0 39"), True, True)
         _check(chess.Board("8/8/8/4k3/5b2/3K4/8/2B5 w - - 0 33"), True, True)
+        _check(chess.Board("3b4/8/8/6b1/8/8/R7/K1k5 w - - 0 1"), False, True)
 
         _check(chess.variant.AtomicBoard("8/3k4/8/8/2N5/8/3K4/8 b - - 0 1"), True, True)
         _check(chess.variant.AtomicBoard("8/4rk2/8/8/8/8/3K4/8 w - - 0 1"), True, True)


### PR DESCRIPTION
I believe that the correct way, or at least widely accepted way of writing the castle move (long and short) is with zeros. That's the way I generally write it too. So, inside the `parse_san` function, I've added replacing all zeros in the `san` string with 'O', so that it doesn't throw an error but instead recognizes the move as castling.

I couldn't really find any reference where the SAN notation for castling is defined. But, it is definitely used by many. I guess both with 'O' and with '0' is valid. I understand that `parse_san` will still return the parsed move with 'O's in it, but I think that's fine as other functions like `xboard` are doing the same.

P.S. I have no idea why it is showing 20 commits. I just did one. I tried to update my fork by pulling the main repo's commits into mine and then I added my thing. I think that essentially, only one file should be different (`__init__.py`) but I am very confused, sorry. Oh no, one of the checks failed. Does anybody know how I can fix this?