### PR TITLE
Add a missing dot at the end of a comment

### DIFF
--- a/docs/variant.rst
+++ b/docs/variant.rst
@@ -7,7 +7,7 @@ python-chess supports several chess variants.
 >>>
 >>> board = chess.variant.GiveawayBoard()
 
->>> # General information about the variants
+>>> # General information about the variants.
 >>> type(board).uci_variant
 'giveaway'
 >>> type(board).xboard_variant


### PR DESCRIPTION
Since this is not an inline comment, the dot is needed. Even though this comment is commenting an example code, the dot is still needed.