### PR TITLE
Remove redundant comma

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ New in v1.2.2
 
 Bugfixes:
 
-* Fixed regression, where releases were uploaded without the ``py.typed``
+* Fixed regression where releases were uploaded without the ``py.typed``
   marker.
 
 New in v1.2.1


### PR DESCRIPTION
There's no comma needed in this particular sentence in CHANGELOG.rst. So it was removed.