### PR TITLE
Add an 'a'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ New in v1.2.2
 
 Bugfixes:
 
-* Fixed regression where releases were uploaded without the ``py.typed``
+* Fixed a regression where releases were uploaded without the ``py.typed``
   marker.
 
 New in v1.2.1


### PR DESCRIPTION
Added an 'a' in "Fixed regression" to correctly say "Fixed a regression" now. Sorry for not noticing this in the previous PR.