### PR TITLE
document `legal_drop_squares` and remove unnecessary copies in `_Craz…

### DIFF
--- a/chess/variant.py
+++ b/chess/variant.py
@@ -616,8 +616,8 @@ class _CrazyhouseBoardState(Generic[CrazyhouseBoardT], chess._BoardState[Crazyho
 
     def restore(self, board: CrazyhouseBoardT) -> None:
         super().restore(board)
-        board.pockets[chess.WHITE] = self.pockets_w.copy()
-        board.pockets[chess.BLACK] = self.pockets_b.copy()
+        board.pockets[chess.WHITE] = self.pockets_w
+        board.pockets[chess.BLACK] = self.pockets_b
 
 CrazyhousePocketT = TypeVar("CrazyhousePocketT", bound="CrazyhousePocket")
 
@@ -727,6 +727,13 @@ class CrazyhouseBoard(chess.Board):
             return chess.BB_EMPTY
 
     def legal_drop_squares(self) -> chess.SquareSet:
+        """
+        Get the squares where a legal drop is possible for the side to move.
+
+        It is legal to drop a checkmate.
+        
+        Returns a :class:`set of squares <chess.SquareSet>`.
+        """
         return chess.SquareSet(self.legal_drop_squares_mask())
 
     def is_pseudo_legal(self, move: chess.Move) -> bool:


### PR DESCRIPTION
…yhouseBoardState`

`legal_drop_squares` was not documented yet not used in the code source and considering it returns a `chess.SquareSet` I think it was intented to be exposed to the users.

when restoring a previous position form a `_CrazyhouseBoardState` it's not necessary to make a copy of the pocket since the instance is discarded. Also it's not intented to be publicly used. 

My only worry is that it can be considered as a breaking change stricto sensu. In that case I can make a commit only with doc change if deemed reasonable.

All test passed.

As always, thanks for making such a great lib!