### PR TITLE
Fix variation_san() output format + its docstring

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2889,8 +2889,8 @@ class Board(BaseBoard):
     def variation_san(self, variation: Iterable[Move]) -> str:
         """
         Given a sequence of moves, returns a string representing the sequence
-        in standard algebraic notation (e.g., ``1. e4 e5 2. Nf3 Nc6`` or
-        ``37...Bg6 38. fxg6``).
+        in standard algebraic notation (e.g., ``1.e4 e5 2.Nf3 Nc6``, or
+        ``37...Bg6 38.fxg6``).
 
         The board will not be modified as a result of calling this.
 
@@ -2904,7 +2904,7 @@ class Board(BaseBoard):
                 raise ValueError(f"illegal move {move} in position {board.fen()}")
 
             if board.turn == WHITE:
-                san.append(f"{board.fullmove_number}. {board.san_and_push(move)}")
+                san.append(f"{board.fullmove_number}.{board.san_and_push(move)}")
             elif not san:
                 san.append(f"{board.fullmove_number}...{board.san_and_push(move)}")
             else:


### PR DESCRIPTION
The sequence of chess moves of a variation are written as, e.g., "1.e4 e5 2.Nf3 Nc6", so there's no space after the dot. In all chess publications I could find, I found this format.