### PR TITLE
Use full move stack for UCI pondering

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1581,9 +1581,10 @@ class UciProtocol(Protocol):
 
                     if ponder and best.move and best.ponder:
                         self.pondering = True
-                        engine.board.push(best.move)
-                        engine.board.push(best.ponder)
-                        engine._position(engine.board)
+                        pondering_board = board.copy()
+                        pondering_board.push(best.move)
+                        pondering_board.push(best.ponder)
+                        engine._position(pondering_board)
                         engine._go(limit, ponder=True)
 
                 if not self.pondering:


### PR DESCRIPTION
Refer to secondary part of issue #757. Before sending a `go ponder` command to a UCI engine, this will send the entire move stack to the engine in a `position` command instead of just the current FEN followed by the `bestmove` and `ponder` move.