### PR TITLE
Uci ponderhit

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1602,14 +1602,13 @@ class UciProtocol(Protocol):
 
                         time_used = time.perf_counter() - self.start_time
                         ponder_limit = copy.copy(limit)
-                        if pondering_board.turn == chess.WHITE:
-                            if ponder_limit.white_clock:
+                        if ponder_limit.white_clock is not None or ponder_limit.black_clock is not None:
+                            ponder_limit.white_clock += (ponder_limit.white_inc or 0.0)
+                            ponder_limit.black_clock += (ponder_limit.black_inc or 0.0)
+                            if pondering_board.turn == chess.WHITE:
                                 ponder_limit.white_clock -= time_used
-                                ponder_limit.white_clock += (ponder_limit.white_inc or 0.0)
-                        else:
-                            if ponder_limit.black_clock:
+                            else:
                                 ponder_limit.black_clock -= time_used
-                                ponder_limit.black_clock += (ponder_limit.black_inc or 0.0)
 
                         if ponder_limit.remaining_moves:
                             ponder_limit.remaining_moves -= 1

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1534,7 +1534,8 @@ class UciProtocol(Protocol):
         self.send_line(" ".join(builder))
 
     async def play(self, board: chess.Board, limit: Limit, *, game: object = None, info: Info = INFO_NONE, ponder: bool = False, root_moves: Optional[Iterable[chess.Move]] = None, options: ConfigMapping = {}) -> PlayResult:
-        self.last_move = board.move_stack[-1] if (ponder and board.move_stack) else chess.Move.null()
+        same_game = not self.first_game and game == self.game and not options
+        self.last_move = board.move_stack[-1] if (same_game and ponder and board.move_stack) else chess.Move.null()
 
         class UciPlayCommand(BaseCommand[UciProtocol, PlayResult]):
             def start(self, engine: UciProtocol) -> None:

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1540,7 +1540,7 @@ class UciProtocol(Protocol):
             def start(self, engine: UciProtocol) -> None:
                 self.info: InfoDict = {}
                 self.pondering = False
-                self.ponder_move = None
+                self.ponder_move = chess.Move.null()
                 self.sent_isready = False
                 self.start_time = time.perf_counter()
 
@@ -1616,7 +1616,7 @@ class UciProtocol(Protocol):
 
                         engine._go(ponder_limit, ponder=True)
                     else:
-                        self.ponder_move = None
+                        self.ponder_move = chess.Move.null()
 
                 if not self.pondering:
                     self.end(engine)

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1534,7 +1534,7 @@ class UciProtocol(Protocol):
         self.send_line(" ".join(builder))
 
     async def play(self, board: chess.Board, limit: Limit, *, game: object = None, info: Info = INFO_NONE, ponder: bool = False, root_moves: Optional[Iterable[chess.Move]] = None, options: ConfigMapping = {}) -> PlayResult:
-        self.last_move = board.move_stack[-1] if board.move_stack else None
+        self.last_move = board.move_stack[-1] if (ponder and board.move_stack) else chess.Move.null()
 
         class UciPlayCommand(BaseCommand[UciProtocol, PlayResult]):
             def start(self, engine: UciProtocol) -> None:

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1395,6 +1395,8 @@ class UciProtocol(Protocol):
     def _ucinewgame(self) -> None:
         self.send_line("ucinewgame")
         self.first_game = False
+        self.ponder_move = None
+        self.ponderhit = False
 
     def debug(self, on: bool = True) -> None:
         """

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1553,6 +1553,7 @@ class UciProtocol(Protocol):
 
                 if engine.ponderhit:
                     engine.ponderhit = False
+                    engine.send_line("ponderhit")
                     return
 
                 if engine.first_game or engine.game != game:
@@ -1610,7 +1611,6 @@ class UciProtocol(Protocol):
                     engine.ponderhit = True
                     engine.ponder_move = None
                     self.end(engine)
-                    engine.send_line("ponderhit")
                 else:
                     engine.send_line("stop")
 

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1603,13 +1603,13 @@ class UciProtocol(Protocol):
                         time_used = time.perf_counter() - self.start_time
                         ponder_limit = copy.copy(limit)
                         if pondering_board.turn == chess.WHITE:
-                            if limit.white_clock:
+                            if ponder_limit.white_clock:
                                 ponder_limit.white_clock -= time_used
-                                ponder_limit.white_clock += (limit.white_inc or 0.0)
+                                ponder_limit.white_clock += (ponder_limit.white_inc or 0.0)
                         else:
-                            if limit.black_clock:
+                            if ponder_limit.black_clock:
                                 ponder_limit.black_clock -= time_used
-                                ponder_limit.black_clock += (limit.black_inc or 0.0)
+                                ponder_limit.black_clock += (ponder_limit.black_inc or 0.0)
 
                         if ponder_limit.remaining_moves:
                             ponder_limit.remaining_moves -= 1

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1602,12 +1602,15 @@ class UciProtocol(Protocol):
 
                         time_used = time.perf_counter() - self.start_time
                         ponder_limit = copy.copy(limit)
-                        if ponder_limit.white_clock is not None or ponder_limit.black_clock is not None:
+
+                        if ponder_limit.white_clock is not None:
                             ponder_limit.white_clock += (ponder_limit.white_inc or 0.0)
-                            ponder_limit.black_clock += (ponder_limit.black_inc or 0.0)
                             if pondering_board.turn == chess.WHITE:
                                 ponder_limit.white_clock -= time_used
-                            else:
+
+                        if ponder_limit.black_clock is not None:
+                            ponder_limit.black_clock += (ponder_limit.black_inc or 0.0)
+                            if pondering_board.turn == chess.BLACK:
                                 ponder_limit.black_clock -= time_used
 
                         if ponder_limit.remaining_moves:


### PR DESCRIPTION
This set of changes implements the UCI protocol's `ponderhit` command to let engines switch directly from pondering to move searching if an opponent plays the ponder move from the `bestmove` command.

How this works:

1. When `engine.play()` is called the last move on the board is saved.
2. If the previous `UciPlayCommand` is still active with a pondering engine, it's `cancel()` method compares the new last move on the board with its own `ponder_move`. If they match, the next `UciPlayCommand` will send `ponderhit` (controlled by the `engine.ponderhit` field) instead of `position ...` and `go ...`. Otherwise, it sends `stop` to the engine and ignores the next `bestmove` line from the engine.
3. The next `UciPlayCommand` waits for a `bestmove` line from the engine.

The command `ponderhit` is not sent in the `cancel()` method in order make sure the newest `UciPlayCommand` is active and will catch the next `bestmove` line from the engine.

This change also adjusts the time limit before setting the engine to pondering. The adjustments are meant to estimate the current state of the engines clock after choosing a move.

The reference issue is #757.