### PR TITLE
read_game: don't pop/end_variation while skipping

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -1599,7 +1599,7 @@ def read_game(handle: TextIO, *, Visitor: Any = GameBuilder) -> Any:
             elif token == ")":
                 if skip_variation_depth:
                     skip_variation_depth -= 1
-                if len(board_stack) > 1:
+                elif len(board_stack) > 1:
                     visitor.end_variation()
                     board_stack.pop()
             elif skip_variation_depth:


### PR DESCRIPTION
If the Visitor class enters a variation without skipping, then returns SKIP for a variation nested inside it, the traversal state is messed up when the inside variation ends.  If our skip depth is anything greater than zero when we reach a ')' token, we should not visit the end of a variation or pop the board_stack, because it is being skipped completely.

Short testcase:

```python
import chess, chess.pgn as pgn, io

class MainlineW(pgn.GameBuilder):
    """Includes variations played by Black but not by White"""
    def begin_variation(self):
        if self.variation_stack[-1].turn() != chess.WHITE:
            return pgn.SKIP
        return super().begin_variation()

g = pgn.read_game(io.StringIO(
        '1. e4 e5 (1... d5 2.exd5 Qxd5 3. Nc3 (3. c4) 3... Qa5)'),
    Visitor=MainlineW)
```