### PR TITLE
docs: Fix a few typos

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2045,7 +2045,7 @@ class Board(BaseBoard):
         Checks if the player to move can claim a draw by threefold repetition.
 
         Draw by threefold repetition can be claimed if the position on the
-        board occured for the third time or if such a repetition is reached
+        board occurred for the third time or if such a repetition is reached
         with one of the possible legal moves.
 
         Note that checking this can be slow: In the worst case
@@ -2070,7 +2070,7 @@ class Board(BaseBoard):
         while switchyard:
             self.push(switchyard.pop())
 
-        # Threefold repetition occured.
+        # Threefold repetition occurred.
         if transpositions[transposition_key] >= 3:
             return True
 

--- a/chess/syzygy.py
+++ b/chess/syzygy.py
@@ -1495,7 +1495,7 @@ class Tablebase:
 
     If *max_fds* is not ``None``, will at most use *max_fds* open file
     descriptors at any given time. The least recently used tables are closed,
-    if nescessary.
+    if necessary.
     """
     def __init__(self, *, max_fds: Optional[int] = 128, VariantBoard: Type[chess.Board] = chess.Board) -> None:
         self.variant = VariantBoard


### PR DESCRIPTION
There are small typos in:
- chess/__init__.py
- chess/syzygy.py

Fixes:
- Should read `necessary` rather than `nescessary`.
- Should read `occurred` rather than `occured`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md