### PR TITLE
docs: update missing documentation for `is_fifty_moves()`

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2011,19 +2011,20 @@ class Board(BaseBoard):
         return self.can_claim_fifty_moves() or self.can_claim_threefold_repetition()
 
     def is_fifty_moves(self) -> bool:
+        """
+        Checks that the clock of halfmoves since the last capture or pawn move
+        is greater or equal to 100, and that no other means of ending the game
+        (like checkmate) take precedence.
+        """
         return self._is_halfmoves(100)
 
     def can_claim_fifty_moves(self) -> bool:
         """
         Checks if the player to move can claim a draw by the fifty-move rule.
 
-        :func:`~chess.Board.is_fifty_moves()` checks that the clock of
-        halfmoves since the last capture or pawn move is greater or equal
-        to 100, and that no other means of ending the game (like checkmate)
-        take precedence.
-
-        In addition, the fifty-move rule can also be claimed if there is a
-        legal move that achieves this condition.
+        In addition to :func:`~chess.Board.is_fifty_moves()`, the fifty-move
+        rule can also be claimed if there is a legal move that achieves this
+        condition.
         """
         if self.is_fifty_moves():
             return True


### PR DESCRIPTION
Together with @antonplagemann and @piuswalter I would like to propose a change to the documentation. We share the opinion, that `is_fifty_moves()` should be listed explicitly as a member function in the documentation, because otherwise it is really hard to notice this function even exists.