### PR TITLE
pgn: Improve validation of symbol tokens for tag names

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -93,9 +93,9 @@ NAG_BLACK_SEVERE_TIME_PRESSURE = 139
 NAG_NOVELTY = 146
 
 
-TAG_REGEX = re.compile(r"^\[([A-Za-z0-9_+#=:-]+)\s+\"([^\r]*)\"\]\s*$")
+TAG_REGEX = re.compile(r"^\[([A-Za-z0-9][A-Za-z0-9_+#=:-]{,254})\s+\"([^\r]*)\"\]\s*$")
 
-TAG_NAME_REGEX = re.compile(r"^[A-Za-z0-9_+#=:-]+\Z")
+TAG_NAME_REGEX = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_+#=:-]{,254}\Z")
 
 MOVETEXT_REGEX = re.compile(r"""
     (


### PR DESCRIPTION
Currently `chess.pgn` treats any tag name consisting of all symbol continuation characters as valid.  But per [PGN spec](http://www.saremba.de/chessgml/standards/pgn/pgn-complete.htm#c7) (bolding mine) -
> A symbol token **starts with a letter or digit character** and is immediately followed by a sequence of zero or more symbol continuation characters. ... Currently, a symbol is limited to a maximum of 255 characters in length.

This patch adds these two criteria for PGN tag names.