### PR TITLE
pgn: Skip over invalid or malformed headers

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -1538,7 +1538,9 @@ def read_game(handle: TextIO, *, Visitor: Any = GameBuilder) -> Any:
                 if unmanaged_headers is not None:
                     unmanaged_headers[tag_match.group(1)] = tag_match.group(2)
             else:
-                break
+                # Ignore invalid or malformed headers.
+                line = handle.readline()
+                continue
 
         line = handle.readline()
 


### PR DESCRIPTION
From https://github.com/niklasf/python-chess/issues/904#issue-1297715055 -
> Based on that quote, it seems the expected behavior would be for `chess.pgn` to parse the file as if the bad tag weren't there; 

With this patch `chess.pgn` now does this in most cases.