### PR TITLE
Update docs

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -1470,6 +1470,10 @@ def read_game(handle: TextIO, *, Visitor: Any = GameBuilder) -> Any:
 
     >>> pgn = open("data/pgn/kasparov-deep-blue-1997.pgn", encoding="utf-8")
 
+    If you get a UnicodeDecodeError, including the following parameters might help:
+
+    >>> pgn = open("data/pgn/kasparov-deep-blue-1997.pgn", 'r', errors='replace')
+
     Use :class:`~io.StringIO` to parse games from a string.
 
     >>> import io


### PR DESCRIPTION
I was trying to open a pgn, but received a UnicodeDecodeError. Adding 'r' and errors='replace' as arguments to open() solved the issue for me. 
Used the top answer here: https://stackoverflow.com/questions/35028683/python3-unicodedecodeerror-with-readlines-method

This PR just updates the documentation to include this, in case anyone else has a similar problem.