### PR TITLE
Add specific move error exceptions

### DIFF
--- a/chess/variant.py
+++ b/chess/variant.py
@@ -989,7 +989,7 @@ class CrazyhouseBoard(chess.Board):
                 uci = "P" + uci
             move = chess.Move.from_uci(uci)
             if not self.is_legal(move):
-                raise ValueError(f"illegal drop san: {san!r} in {self.fen()}")
+                raise chess.IllegalMoveError(f"illegal drop san: {san!r} in {self.fen()}")
             return move
         else:
             return super().parse_san(san)


### PR DESCRIPTION
Currently, when an invalid, illegal, or ambiguous move is attempted a `ValueError` is raised (with differing messages regarding the error). If a library user is interested in displaying a custom error to the user such as: "_That move is ambiguous_" the only option in this case is to parse the `ValueError` message for "_ambiguous_" and then handle presenting a message regarding the ambiguous move accordingly.

This pull request brings in _specific_ move exceptions (`InvalidMoveError`, `IllegalMoveError`, `AmbiguousMoveError`, and `PromotionMoveError`) and raises them accordingly. All of these new exceptions inherit from `ValueError` and provide the same messages as before to allow for full backwards compatibility since the base `ValueError` can still be caught in all of these situations.

This is purely just a "this would be nice to have" pull request as I know there are existing unit tests in place to verify the messages are not changed of the currently raised `ValueErrors`, but it would be nice to not have to parse the messages.

I completely understand declining this pull request if you believe this opens Pandora's box with the other existing `ValueErrors` (like FEN parsing, etc) or if you think this would be difficult to maintain.