### PR TITLE
strip option args

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1377,7 +1377,7 @@ class UciProtocol(Protocol):
                 current_var = None
                 var = []
 
-                for token in arg.split(" "):
+                for token in arg.strip().split(" "):
                     if token == "name" and not name:
                         current_parameter = "name"
                     elif token == "type" and not type:


### PR DESCRIPTION
Strip leading and trailing whitespaces.
Currently implementation works just fine, however there are "buggy" engines which send another whitespace after the final token which is not required.