### PR TITLE
Support implicit resigning from Xboard engines

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -2197,6 +2197,8 @@ class XBoardProtocol(Protocol):
                         self.play_result.resigned = True
                     self._ping_after_move(engine)
                 elif line.startswith("1-0") or line.startswith("0-1") or line.startswith("1/2-1/2"):
+                    if "resign" in line and not self.result.done():
+                        self.play_result.resigned = True
                     self._ping_after_move(engine)
                 elif line.startswith("#"):
                     pass


### PR DESCRIPTION
An XBoard engine is allowed to resign by putting the string "resign" somewhere in the comment of a "1-0" or "0-1" command. For example, "0-1 {White resigns}".

Closes #964