### PR TITLE
Remove unused ponderhit code

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1577,9 +1577,6 @@ class UciProtocol(Protocol):
         self.send_line(" ".join(builder))
 
     async def play(self, board: chess.Board, limit: Limit, *, game: object = None, info: Info = INFO_NONE, ponder: bool = False, draw_offered: bool = False, root_moves: Optional[Iterable[chess.Move]] = None, options: ConfigMapping = {}) -> PlayResult:
-        same_game = not self.first_game and game == self.game and not options
-        self.last_move = board.move_stack[-1] if (same_game and ponder and board.move_stack) else chess.Move.null()
-
         class UciPlayCommand(BaseCommand[UciProtocol, PlayResult]):
             def __init__(self, engine: UciProtocol):
                 super().__init__(engine)


### PR DESCRIPTION
Remove old unused code. These changes were added a few years back [here](https://github.com/niklasf/python-chess/pull/759) and later cleaned up [here](https://github.com/niklasf/python-chess/commit/aa1d28faff86f4d639f24e88a38c1a82a12ef093). It appears that these lines are stragglers from the fixes/cleanup.