### PR TITLE
Add square_manhattan_distance and square_knight_distance functions

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -220,25 +220,18 @@ def square_distance(a: Square, b: Square) -> int:
     """
     Gets the Chebyshev distance (i.e., the number of king steps) from square *a* to *b*.
     """
-    if a == b:
-        return 0;
     return max(abs(square_file(a) - square_file(b)), abs(square_rank(a) - square_rank(b)))
 
 def square_manhattan_distance(a: Square, b: Square) -> int:
     """
     Gets the Manhattan/Taxicab distance (i.e., the number of orthogonal king steps) from square *a* to *b*.
     """
-    if a == b:
-        return 0;
     return abs(square_file(a) - square_file(b)) + abs(square_rank(a) - square_rank(b))
 
 def square_knight_distance(a: Square, b: Square) -> int:
     """
     Gets the Knight distance (i.e., the number of knight moves) from square *a* to *b*.
     """
-    if a == b:
-        return 0;
-
     dx = abs(square_file(a) - square_file(b))
     dy = abs(square_rank(a) - square_rank(b))
 
@@ -247,7 +240,7 @@ def square_knight_distance(a: Square, b: Square) -> int:
     elif dx == dy == 2:
         return 4
     elif dx == dy == 1:
-        if 1 << a & BB_CORNERS or 1 << b & BB_CORNERS: # Special case only for corner squares
+        if BB_SQUARES[a] & BB_CORNERS or BB_SQUARES[b] & BB_CORNERS: # Special case only for corner squares
             return 4
 
     m = math.ceil(max(dx / 2, dy / 2, (dx + dy) / 3))

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -218,9 +218,40 @@ def square_rank(square: Square) -> int:
 
 def square_distance(a: Square, b: Square) -> int:
     """
-    Gets the distance (i.e., the number of king steps) from square *a* to *b*.
+    Gets the Chebyshev distance (i.e., the number of king steps) from square *a* to *b*.
     """
+    if a == b:
+        return 0;
     return max(abs(square_file(a) - square_file(b)), abs(square_rank(a) - square_rank(b)))
+
+def square_manhattan_distance(a: Square, b: Square) -> int:
+    """
+    Gets the Manhattan/Taxicab distance (i.e., the number of orthogonal king steps) from square *a* to *b*.
+    """
+    if a == b:
+        return 0;
+    return abs(square_file(a) - square_file(b)) + abs(square_rank(a) - square_rank(b))
+
+def square_knight_distance(a: Square, b: Square) -> int:
+    """
+    Gets the Knight distance (i.e., the number of knight moves) from square *a* to *b*.
+    """
+    if a == b:
+        return 0;
+
+    dx = abs(square_file(a) - square_file(b))
+    dy = abs(square_rank(a) - square_rank(b))
+
+    if dx + dy == 1:
+        return 3
+    elif dx == dy == 2:
+        return 4
+    elif dx == dy == 1:
+        if 1 << a & BB_CORNERS or 1 << b & BB_CORNERS: # Special case only for corner squares
+            return 4
+
+    m = math.ceil(max(dx / 2, dy / 2, (dx + dy) / 3))
+    return m + ((m + dx + dy) % 2)
 
 def square_mirror(square: Square) -> Square:
     """Mirrors the square vertically."""

--- a/test.py
+++ b/test.py
@@ -93,6 +93,31 @@ class SquareTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.assertEqual(chess.parse_square("a0"))
 
+    def test_square_distance(self):
+        self.assertEqual(chess.square_distance(chess.A1, chess.A1), 0)
+        self.assertEqual(chess.square_distance(chess.A1, chess.H8), 7)
+        self.assertEqual(chess.square_distance(chess.E1, chess.E8), 7)
+        self.assertEqual(chess.square_distance(chess.A4, chess.H4), 7)
+        self.assertEqual(chess.square_distance(chess.D4, chess.E5), 1)
+
+    def test_square_manhattan_distance(self):
+        self.assertEqual(chess.square_manhattan_distance(chess.A1, chess.A1), 0)
+        self.assertEqual(chess.square_manhattan_distance(chess.A1, chess.H8), 14)
+        self.assertEqual(chess.square_manhattan_distance(chess.E1, chess.E8), 7)
+        self.assertEqual(chess.square_manhattan_distance(chess.A4, chess.H4), 7)
+        self.assertEqual(chess.square_manhattan_distance(chess.D4, chess.E5), 2)
+
+    def test_square_knight_distance(self):
+        self.assertEqual(chess.square_knight_distance(chess.A1, chess.A1), 0)
+        self.assertEqual(chess.square_knight_distance(chess.A1, chess.H8), 6)
+        self.assertEqual(chess.square_knight_distance(chess.G1, chess.F3), 1)
+        self.assertEqual(chess.square_knight_distance(chess.E1, chess.E8), 5)
+        self.assertEqual(chess.square_knight_distance(chess.A4, chess.H4), 5)
+        self.assertEqual(chess.square_knight_distance(chess.A1, chess.B1), 3)
+        self.assertEqual(chess.square_knight_distance(chess.A1, chess.C3), 4)
+        self.assertEqual(chess.square_knight_distance(chess.A1, chess.B2), 4)
+        self.assertEqual(chess.square_knight_distance(chess.C1, chess.B2), 2)
+
 
 class MoveTestCase(unittest.TestCase):
 


### PR DESCRIPTION
The chess library includes a function called square_distance, which calculates the Chebyshev distance (number of king steps) between 2 squares. This way of measuring distance is not always sufficient though, so I added two new distance functions.

- square_manhattan_distance calculates the Manhattan or Taxicab distance between 2 squares. This is the minimal number of orthogonal king moves it would take to travel from one square to another.

- square_knight_distance calculates the knight distance (using a pretty weird formula), which is the minimal number of knight moves to travel from one square to another