### PR TITLE
PGN: introduce add_line_by_san

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -400,6 +400,28 @@ class GameNode(abc.ABC):
 
         return node
 
+    def add_line_by_san(self, sans: Iterable[str], *, comment: str = "", starting_comment: str = "", nags: Iterable[int] = []) -> GameNode:
+        """
+        Creates a sequence of child nodes for the given list of moves in standard algebraic notation.
+        Adds *comment* and *nags* to the last node of the line and returns it.
+        """
+        node = self
+
+        # Add line.
+        for san in sans:
+            node = node.add_variation(node.board().parse_san(san), starting_comment=starting_comment)
+            starting_comment = ""
+
+        # Merge comment and NAGs.
+        if node.comment:
+            node.comment += " " + comment
+        else:
+            node.comment = comment
+
+        node.nags.update(nags)
+
+        return node
+
     def eval(self) -> Optional[chess.engine.PovScore]:
         """
         Parses the first valid ``[%eval ...]`` annotation in the comment of


### PR DESCRIPTION
copied, essentially, from add_line

However, upon reviewing the source, I discovered that `GameNode.board()` is in fact a grossly expensive function, and rebuilding the entire variation history *for every move added* is just intensely wasteful. I intend to use this `add_line_by_san` function on many thousands of games, where each move in the game has a pv line stored in a comment, so the waste in `GameNode.board()` would actually cost potentially many seconds of run time, or otherwise force me to write my traversal code, which would kinda defeat the point of having the pgn module anyways.

I suggest adding a `@cache` decorator to `GameNode.board` and thereafter rewriting the method body to simply refer to `parent.board()`. The result would be the same only much, much more efficient. Please let me know if this is an acceptable plan, and I can make a separate PR. In fact I might anyways