### PR TITLE
Add optional identifier to Limit instances

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -336,7 +336,7 @@ class Limit:
     """
     An identifier to use with XBoard engines to signal that the time
     control has changed. When this field changes, Xboard engines are
-    send level or st commands as appropriate. Otherwise, only time
+    sent level or st commands as appropriate. Otherwise, only time
     and otim commands are sent to update the engine's clock.
     """
 

--- a/test.py
+++ b/test.py
@@ -3713,7 +3713,9 @@ class EngineTestCase(unittest.TestCase):
             mock.assert_done()
 
             limit = chess.engine.Limit(black_clock=65, white_clock=100,
-                                       black_inc=4, white_inc=8)
+                                       black_inc=4, white_inc=8,
+                                       clock_id="xboard level")
+            board = chess.Board()
             mock.expect("new")
             mock.expect("force")
             mock.expect("level 0 1:40 8")
@@ -3723,8 +3725,23 @@ class EngineTestCase(unittest.TestCase):
             mock.expect("easy")
             mock.expect("go", ["move e2e4"])
             mock.expect_ping()
-            result = await protocol.play(chess.Board(), limit)
+            result = await protocol.play(board, limit)
             self.assertEqual(result.move, chess.Move.from_uci("e2e4"))
+            mock.assert_done()
+
+            board.push(result.move)
+            board.push_uci("e7e5")
+
+            mock.expect("force")
+            mock.expect("e7e5")
+            mock.expect("time 10000")
+            mock.expect("otim 6500")
+            mock.expect("nopost")
+            mock.expect("easy")
+            mock.expect("go", ["move d2d4"])
+            mock.expect_ping()
+            result = await protocol.play(board, limit)
+            self.assertEqual(result.move, chess.Move.from_uci("d2d4"))
             mock.assert_done()
 
         asyncio.set_event_loop_policy(chess.engine.EventLoopPolicy())


### PR DESCRIPTION
This new field in the Limit class is used to signal when the time control for a game has changed. XBoard engines expect to receive a `level` or `st` command to indicate the time control at the start of the game, and then only `time` and `otim` commands before each subsequent move to update the engine's internal clocks. The `level` and `st` commands should only be resent when the time control changes--like in FIDE tournament time controls. During a single time control, the same `clock_id` should be used for every Limit instance. This field has a similar function to the `game` parameter of the `play()` method.

Issue with previous discussion: #742