### PR TITLE
Error when XBoard opponent has newline in name

### DIFF
--- a/test.py
+++ b/test.py
@@ -3688,6 +3688,15 @@ class EngineTestCase(unittest.TestCase):
             self.assertEqual(result.move, board.parse_san("e5"))
             mock.assert_done()
 
+            bad_opponent = chess.engine.Opponent("New\nLine", "GM", 1, False)
+            with self.assertRaises(chess.engine.EngineError):
+                await protocol.send_opponent_information(opponent=bad_opponent)
+            mock.assert_done()
+
+            with self.assertRaises(chess.engine.EngineError):
+                result = await protocol.play(board, limit, game="bad game", opponent=bad_opponent)
+            mock.assert_done()
+
         asyncio.set_event_loop_policy(chess.engine.EventLoopPolicy())
         asyncio.run(main())
 


### PR DESCRIPTION
Use the configuration machinery to send the opponent's information to the engine instead of using the Opponent class directly. This will make sure that an exception is raised if the opponent's name has newlines in it before send_line() is called. This prevents opponents from injecting commands into the engine. For example, if an opponent sets their name as "Cheat\neasy", then the following commands will be sent to the local engine

name Cheat
easy

which would cause the engine to turn off pondering.

Also, add tests to show the change works as expected.

Fixes #1018