### PR TITLE
Fix tox.ini comments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,18 @@ commands =
 
 [flake8]
 ignore =
-    E126 E131  # Allow over-indent and unaligned indent
-    E241  # Allow indenting array elements
-    E302 E305  # Allow grouping functions
-    E741  # Allow "ambiguous" variable names
-    W504  # Allow binary operators before EOL (end of line)
-    E704 E301  # Allow "def overloaded(): ..."
-    E722  # Bare except (with or without reraise)
+    # Allow over-indent and unaligned indent
+    E126 E131
+    # Allow indenting array elements
+    E241
+    # Allow grouping functions
+    E302 E305
+    # Allow "ambiguous" variable names
+    E741
+    # Allow binary operators before EOL (end of line)
+    W504
+    # Allow "def overloaded(): ..."
+    E704 E301
+    # Bare except (with or without reraise)
+    E722
 max-line-length = 160


### PR DESCRIPTION
Latest version of flake8 no longer allows inline comments in config file.

Issue: https://github.com/PyCQA/flake8/issues/1689
PR: https://github.com/PyCQA/flake8/pull/1713