### PR TITLE
Lenient whitespace parsing for engines

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1324,7 +1324,7 @@ class UciProtocol(Protocol):
                 current_var = None
                 var = []
 
-                for token in arg.strip().split(" "):
+                for token in arg.split():
                     if token == "name" and not name:
                         current_parameter = "name"
                     elif token == "type" and not type:

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1324,7 +1324,7 @@ class UciProtocol(Protocol):
                 current_var = None
                 var = []
                 
-                def parse_min_max_value(token: str, which: Literal["min", "max"]):
+                def parse_min_max_value(token: str, which: Literal["min", "max"]) -> Optional[int]:
                     try:
                         return int(token)
                     except ValueError:

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1320,7 +1320,7 @@ class UciProtocol(Protocol):
 
                 parameters = list(option_parts.keys()) + ['var']
                 option_regex = fr"\s*({'|'.join(parameters)})\s*"
-                for token in re.split(option_regex, arg):
+                for token in re.split(option_regex, arg.strip()):
                     if token == "var" or (token in option_parts and not option_parts[token]):
                         current_parameter = token
                     elif current_parameter == "var":

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -10,14 +10,12 @@ import dataclasses
 import enum
 import logging
 import math
-import warnings
 import shlex
 import subprocess
 import sys
 import threading
 import time
 import typing
-import os
 import re
 
 import chess

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1274,9 +1274,6 @@ class BaseCommand(Generic[ProtocolT, T]):
         return "<{} at {:#x} (state={}, result={}, finished={}>".format(type(self).__name__, id(self), self.state, self.result, self.finished)
 
 
-UCI_OPTION_REGEX = re.compile(r"\s*(name|type|default|min|max|var)\s*")
-
-
 class UciProtocol(Protocol):
     """
     An implementation of the
@@ -1321,7 +1318,9 @@ class UciProtocol(Protocol):
                 option_parts: dict[str, str] = {k: "" for k in ["name", "type", "default", "min", "max"]}
                 var = []
 
-                for token in UCI_OPTION_REGEX.split(arg):
+                parameters = list(option_parts.keys()) + ['var']
+                option_regex = fr"\s*({'|'.join(parameters)})\s*"
+                for token in re.split(option_regex, arg):
                     if token == "var" or (token in option_parts and not option_parts[token]):
                         current_parameter = token
                     elif current_parameter == "var":

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1323,7 +1323,7 @@ class UciProtocol(Protocol):
                 max = None
                 current_var = None
                 var = []
-                
+
                 def parse_min_max_value(token: str, which: Literal["min", "max"]) -> Optional[int]:
                     try:
                         return int(token)
@@ -1742,7 +1742,7 @@ def _create_variation_line(root_board: chess.Board, line: str) -> tuple[list[che
             line = remaining_line_after_move
         else:
             return currline, line
-        
+
 
 def _parse_uci_info(arg: str, root_board: chess.Board, selector: Info = INFO_ALL) -> InfoDict:
     info: InfoDict = {}

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1387,7 +1387,7 @@ class UciProtocol(Protocol):
                 engine._isready()
 
             def line_received(self, engine: UciProtocol, line: str) -> None:
-                if line == "readyok":
+                if line.strip() == "readyok":
                     self.result.set_result(None)
                     self.set_finished()
                 else:

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1323,6 +1323,13 @@ class UciProtocol(Protocol):
                 max = None
                 current_var = None
                 var = []
+                
+                def parse_min_max_value(token: str, which: Literal["min", "max"]):
+                    try:
+                        return int(token)
+                    except ValueError:
+                        LOGGER.exception(f"Exception parsing option {which}")
+                        return None
 
                 for token in arg.split():
                     if token == "name" and not name:
@@ -1349,15 +1356,9 @@ class UciProtocol(Protocol):
                     elif current_parameter == "var":
                         current_var.append(token)
                     elif current_parameter == "min":
-                        try:
-                            min = int(token)
-                        except ValueError:
-                            LOGGER.exception("Exception parsing option min")
+                        min = parse_min_max_value(token, "min")
                     elif current_parameter == "max":
-                        try:
-                            max = int(token)
-                        except ValueError:
-                            LOGGER.exception("Exception parsing option max")
+                        max = parse_min_max_value(token, "max")
 
                 if current_var is not None:
                     var.append(" ".join(current_var))


### PR DESCRIPTION
Fixes #970

This PR is an attempt at reducing the number of assumptions about what whitespace can appear in messages received from engines. This is done in several parts:
1. A new function `_next_token()` extracts the next whitespace delimited word from a string, returning it with whitespace stripped out along with the rest of the line unchanged. This allows for string equality comparisons instead of `str.startswith()` and for the whitespace in the remaining string to be untouched, unlike with `str.split()`.
2. UCI options are parsed with a regex split that splits off parameter names without changing the whitespace in the parameter values.
3. If a received line is expected to exactly match another string, it will be compared with a `strip()` version of it: `if line.strip() == "readyok"`.

Other repeated code is refactored into functions.