### PR TITLE
Feature/grid labels

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1232,20 +1232,46 @@ class BaseBoard:
                 - dict: it must have 4 keys (Left, Up, Right, Down) with a bool for seeing the value. ({"left":True, "up":False, "right":False, "down":True} would display on the left and bottom side)
                 - list: you list the first letter of the sides you want. (["L", "U", "R", "D"] would display on all sides)
         """
-        if isinstance(labels, dict):
-            self.labels = labels
-        else:
-            x = {"l":"left", "u":"up", "r":"right", "d":"down"}
-            for i in labels:
-                self.labels[x[i.lower()]] = True
-                x[i.lower()] = True
+        if labels == True:
+            self.labels = {"left":True, "up":False, "right":False, "down":True}
+        elif not labels == False:
+            self.labels = {}
+            if isinstance(labels, dict):
+                self.labels = labels
+            else:
+                x = {"l":"left", "u":"up", "r":"right", "d":"down"}
+                for i in labels:
+                    self.labels[x[i.lower()]] = True
+                    x[i.lower()] = True
+                for v in x:
+                    if not v==True:
+                        self.labels[x[v]] = False
+        elif not labels:
+            self.labels = {"left":False, "up":False, "right":False, "down":False}
+
+
+    def __str__(self, labels:typing.Union[list, dict, bool] = True) -> str:
+        df_labels = self.labels
+
+        if labels == True:
+            self.labels = {"left":True, "up":False, "right":False, "down":True}
+        elif not labels == False:
+            self.labels = {}
+            if isinstance(labels, dict):
+                self.labels = labels
+            else:
+                x = {"l":"left", "u":"up", "r":"right", "d":"down"}
+                for i in labels:
+                    self.labels[x[i.lower()]] = True
+                    x[i.lower()] = True
+                for v in x:
+                    if not v==True:
+                        self.labels[x[v]] = False
+        elif not labels:
+            self.labels = {"left":False, "up":False, "right":False, "down":False}
             
-            for k,v in x:
-                if not v:
-                    self.labels[v] = False
 
 
-    def __str__(self) -> str:
         builder: List[str] = []
         row:int = 1
         if self.labels["up"]:
@@ -1303,7 +1329,7 @@ class BaseBoard:
             if self.labels["right"]:
                 builder.append("| ")
         
-
+        self.labels = df_labels
         return "".join(builder)
 
     def unicode(self, *, invert_color: bool = False, borders: bool = False, empty_square: str = "⭘", orientation: Color = WHITE) -> str:
@@ -3908,6 +3934,11 @@ class LegalMoveGenerator:
     def __repr__(self) -> str:
         sans = ", ".join(self.board.san(move) for move in self)
         return f"<LegalMoveGenerator at {id(self):#x} ({sans})>"
+
+    def __getitem__(self):
+        sans = ", ".join(self.board.san(move) for move in self)
+        return list(sans)
+    
 
 
 IntoSquareSet = Union[SupportsInt, Iterable[Square]]

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1248,7 +1248,6 @@ class BaseBoard:
     def __str__(self) -> str:
         builder: List[str] = []
         row:int = 1
-        print(self.labels)
         if self.labels["up"]:
             #Labels
             if self.labels["left"]:
@@ -1264,7 +1263,7 @@ class BaseBoard:
             if self.labels["right"]:
                 builder.append("+-\n")
         if self.labels["left"]:
-            builder.append("1|")
+            builder.append("8|")
             
         for square in SQUARES_180:
             piece = self.piece_at(square)
@@ -1277,10 +1276,10 @@ class BaseBoard:
             if BB_SQUARES[square] & BB_FILE_H:
                 if square != H1:
                     if self.labels["right"]:
-                        builder.append(f"|{round(row/8)}")
+                        builder.append(f"|{9-round(row/8)}")
                     builder.append("\n")
                     if self.labels["left"]:
-                        builder.append(f"{round(row/8)+1}|")
+                        builder.append(f"{8-round(row/8)}|")
             
             else:
                 builder.append(" ")
@@ -1651,12 +1650,9 @@ class Board(BaseBoard):
                 for i in labels:
                     self.labels[x[i.lower()]] = True
                     x[i.lower()] = True
-
-                print(x,self.labels)
                 for v in x:
                     if not v==True:
                         self.labels[x[v]] = False
-                print(x,self.labels)
         elif not labels:
             self.labels = {"left":False, "up":False, "right":False, "down":False}
 

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1223,10 +1223,47 @@ class BaseBoard:
 
     def __repr__(self) -> str:
         return f"{type(self).__name__}({self.board_fen()!r})"
+    
+    def __call__(self, labels:typing.Union[dict, list] = {"left":True, "up":False, "right":False, "down":True}):
+        """
+        Inputs:
+            - Labels: can be assigned a value of a dict or list. 
+                - dict: it must have 4 keys (Left, Up, Right, Down) with a bool for seeing the value. ({"left":True, "up":False, "right":False, "down":True} would display on the left and bottom side)
+                - list: you list the first letter of the sides you want. (["L", "U", "R", "D"] would display on all sides)
+        """
+        if isinstance(labels, dict):
+            self.labels = labels
+        else:
+            x = {"l":"left", "u":"up", "r":"right", "d":"down"}
+            for i in labels:
+                self.labels[x[i.lower()]] = True
+                x[i.lower()] = True
+            
+            for k,v in x:
+                if not v:
+                    self.labels[v] = False
+
 
     def __str__(self) -> str:
         builder: List[str] = []
-
+        row:int = 1
+        if self.labels["up"]:
+            #Labels
+            if self.labels["left"]:
+                builder.append(" |")
+            builder.append("a b c d e f g h")
+            if self.labels["right"]:
+                builder.append("| ")
+            builder.append("\n")
+            #Decoration
+            if self.labels["left"]:
+                builder.append("-+")
+            builder.append("---------------")
+            if self.labels["right"]:
+                builder.append("+-\n")
+        if self.labels["left"]:
+            builder.append("1|")
+            
         for square in SQUARES_180:
             piece = self.piece_at(square)
 
@@ -1237,9 +1274,34 @@ class BaseBoard:
 
             if BB_SQUARES[square] & BB_FILE_H:
                 if square != H1:
+                    if self.labels["right"]:
+                        builder.append(f"|{round(row/8)}")
                     builder.append("\n")
+                    if self.labels["left"]:
+                        builder.append(f"{round(row/8)+1}|")
+            
             else:
                 builder.append(" ")
+            
+            row+=1
+        if self.labels["right"]:
+            builder.append("|8")
+        #decorations
+        if self.labels["down"]:
+            if self.labels["left"]:
+                builder.append("\n-+")
+            builder.append("---------------")
+            #labels
+            
+            if self.labels["right"]:
+                builder.append("+-")
+            builder.append("\n")
+            if self.labels["left"]:
+                builder.append(" |")
+            builder.append("a b c d e f g h")
+            if self.labels["right"]:
+                builder.append("| ")
+        
 
         return "".join(builder)
 
@@ -1466,6 +1528,11 @@ class Board(BaseBoard):
     unless otherwise specified in the optional *fen* argument.
     If *fen* is ``None``, an empty board is created.
 
+    Optionally supports labels. Labels can be assigned a value of a dictionary or list. 
+    If :func:`labels` is a dictionary it must have 4 keys (Left, Up, Right, Down) with a bool for seeing the value. ({"left":True, "up":False, "right":False, "down":True} would display on the left and bottom side)
+    If :func:`labels` is a list the first letter of the sides you want. (["L", "U", "R", "D"] would display on all sides)
+    By deafault it shows labels on the left and bottom
+
     Optionally supports *chess960*. In Chess960, castling moves are encoded
     by a king move to the corresponding rook square.
     Use :func:`chess.Board.from_chess960_pos()` to create a board with one
@@ -1561,7 +1628,25 @@ class Board(BaseBoard):
     manipulation.
     """
 
-    def __init__(self: BoardT, fen: Optional[str] = STARTING_FEN, *, chess960: bool = False) -> None:
+    def __init__(self: BoardT, fen: Optional[str] = STARTING_FEN, *, chess960: bool = False, labels:typing.Union[dict,list] = {"left":True, "up":False, "right":False, "down":True}) -> None:
+        """
+        Inputs:
+            - Labels: can be assigned a value of a dict or list. 
+                - Dictionary: it must have 4 keys (Left, Up, Right, Down) with a bool for seeing the value. ({"left":True, "up":False, "right":False, "down":True} would display on the left and bottom side)
+                - List: you list the first letter of the sides you want. (["L", "U", "R", "D"] would display on all sides)
+        """
+        if isinstance(labels, dict):
+            self.labels = labels
+        else:
+            x = {"l":"left", "u":"up", "r":"right", "d":"down"}
+            for i in labels:
+                self.labels[x[i.lower()]] = True
+                x[i.lower()] = True
+            
+            for k,v in x:
+                if not v:
+                    self.labels[v] = False
+
         BaseBoard.__init__(self, None)
 
         self.chess960 = chess960

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -621,6 +621,7 @@ class BaseBoard:
     """
 
     def __init__(self, board_fen: Optional[str] = STARTING_BOARD_FEN) -> None:
+
         self.occupied_co = [BB_EMPTY, BB_EMPTY]
 
         if board_fen is None:
@@ -1247,6 +1248,7 @@ class BaseBoard:
     def __str__(self) -> str:
         builder: List[str] = []
         row:int = 1
+        print(self.labels)
         if self.labels["up"]:
             #Labels
             if self.labels["left"]:
@@ -1628,25 +1630,35 @@ class Board(BaseBoard):
     manipulation.
     """
 
-    def __init__(self: BoardT, fen: Optional[str] = STARTING_FEN, *, chess960: bool = False, labels:typing.Union[dict,list] = {"left":True, "up":False, "right":False, "down":True}) -> None:
+    def __init__(self: BoardT, fen: Optional[str] = STARTING_FEN, *, chess960: bool = False, labels:typing.Union[dict[str, bool],list[str], bool] = {"left":True, "up":False, "right":False, "down":True}) -> None:
         """
         Inputs:
             - Labels: can be assigned a value of a dict or list. 
                 - Dictionary: it must have 4 keys (Left, Up, Right, Down) with a bool for seeing the value. ({"left":True, "up":False, "right":False, "down":True} would display on the left and bottom side)
                 - List: you list the first letter of the sides you want. (["L", "U", "R", "D"] would display on all sides)
+                - Bool:
+                    True - Returns Chess Board with default labels
+                    False - Returns Chess Board with no labels
         """
-        self.labels = {}
-        if isinstance(labels, dict):
-            self.labels = labels
-        else:
-            x = {"l":"left", "u":"up", "r":"right", "d":"down"}
-            for i in labels:
-                self.labels[x[i.lower()]] = True
-                x[i.lower()] = True
-            
-            for v in x:
-                if not v:
-                    self.labels[v] = False
+        if labels == True:
+            self.labels = {"left":True, "up":False, "right":False, "down":True}
+        elif not labels == False:
+            self.labels = {}
+            if isinstance(labels, dict):
+                self.labels = labels
+            else:
+                x = {"l":"left", "u":"up", "r":"right", "d":"down"}
+                for i in labels:
+                    self.labels[x[i.lower()]] = True
+                    x[i.lower()] = True
+
+                print(x,self.labels)
+                for v in x:
+                    if not v==True:
+                        self.labels[x[v]] = False
+                print(x,self.labels)
+        elif not labels:
+            self.labels = {"left":False, "up":False, "right":False, "down":False}
 
         BaseBoard.__init__(self, None)
 

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1635,6 +1635,7 @@ class Board(BaseBoard):
                 - Dictionary: it must have 4 keys (Left, Up, Right, Down) with a bool for seeing the value. ({"left":True, "up":False, "right":False, "down":True} would display on the left and bottom side)
                 - List: you list the first letter of the sides you want. (["L", "U", "R", "D"] would display on all sides)
         """
+        self.labels = {}
         if isinstance(labels, dict):
             self.labels = labels
         else:
@@ -1643,7 +1644,7 @@ class Board(BaseBoard):
                 self.labels[x[i.lower()]] = True
                 x[i.lower()] = True
             
-            for k,v in x:
+            for v in x:
                 if not v:
                     self.labels[v] = False
 


### PR DESCRIPTION
# Grid Labels

## Explanation:

This push request adds labels to the `__str__` method of `chess.Board` as mentioned in #971. You can set the label when calling `__init__()` of `chess.Board` or `__call__()` of `chess.BaseBoard`. By default, labels are displayed on the bottom and left. You can display them with either a list, dictionary or bool:
- list: enter the first letter of the side (l, b, r, u) of the sides you want to display on
- dictionary: for **every** side (as key) enter a bool: True = display and False = don't display
- bool: True: Display on default sides (bottom and left), False : Don't display any

## Examples


### Currently:

```
r n b q k b n r
p p p p p p p p
. . . . . . . .
. . . . . . . .
. . . . . . . .
. . . . . . . .
P P P P P P P P
R N B Q K B N R
```

### Default:
```
1|r n b q k b n r
2|p p p p p p p p
3|. . . . . . . .
4|. . . . . . . .
5|. . . . . . . .
6|. . . . . . . .
7|P P P P P P P P
8|R N B Q K B N R
-+---------------
 |a b c d e f g h
```

### All sides:
```
 |a b c d e f g h|
-+---------------+-
1|r n b q k b n r|1
2|p p p p p p p p|2
3|. . . . . . . .|3
4|. . . . . . . .|4
5|. . . . . . . .|5
6|. . . . . . . .|6
7|P P P P P P P P|7
8|R N B Q K B N R|8
-+---------------+-
 |a b c d e f g h|
```