### PR TITLE
Handle multiple comments on a move/variation/game

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -197,13 +197,13 @@ class GameNode(abc.ABC):
     variations: List[ChildNode]
     """A list of child nodes."""
 
-    comments: list[str]
+    comment: list[str]
     """
     Comments that go behind the move leading to this node. Comments
     that occur before any moves are assigned to the root node.
     """
 
-    starting_comments: list[str]
+    starting_comment: list[str]
     nags: Set[int]
 
     def __init__(self, *, comment: Union[str, list[str]] = "") -> None:

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -201,9 +201,8 @@ class GameNodeComment:
         """Create a string representation of the comments in PGN format."""
         comments = list(map(lambda s: s.replace("{", ""), self._comments))
         comments = list(map(lambda s: s.replace("}", "").strip(), comments))
-        output_comments = GameNodeComment(comments)
-        output_comments.remove_empty()
-        return "{ " + output_comments.join(" } { ") + " }"
+        comments = list(filter(None, comments))
+        return "{ " + " } { ".join(comments) + " }"
 
     def remove_empty(self) -> None:
         """Remove empty comments from the comment list."""

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -184,6 +184,70 @@ class _AcceptFrame:
         self.in_variation = False
 
 
+class GameNodeComment:
+    """
+    PGN Comment Storage
+
+    A class that can hold one or more comments for a GameNode.
+    """
+    def __init__(self, comment: Union[str, list[str]] = ""):
+        self.set(comment)
+
+    def set(self, new_comment: Union[str, list[str]]):
+        """Replace the comment with a new comment or a list of comments."""
+        self._comments = new_comment if isinstance(new_comment, list) else [new_comment] if new_comment else []
+
+    def pgn_format(self) -> str:
+        """Create a string representation of the comments in PGN format."""
+        comments = list(map(lambda s: s.replace("{", ""), self._comments))
+        comments = list(map(lambda s: s.replace("}", "").strip(), comments))
+        output_comments = GameNodeComment(comments)
+        output_comments.remove_empty()
+        return "{ " + output_comments.join(" } { ") + " }"
+
+    def remove_empty(self) -> None:
+        """Remove empty comments from the comment list."""
+        self._comments = list(filter(None, self._comments))
+
+    def append(self, new_comment: str) -> None:
+        """Append a new comment to the end of the comment list."""
+        self._comments.append(new_comment)
+
+    def extend(self, new_comments: list[str]) -> None:
+        """Append several new comments to the end of the comment list."""
+        self._comments.extend(new_comments)
+
+    def insert(self, index: int, new_comment: str) -> None:
+        """Insert a new comment before the specified index."""
+        self._comments.insert(index, new_comment)
+
+    def join(self, joiner: str) -> str:
+        """Join all of the comments together with a joiner string between each."""
+        return joiner.join(self._comments)
+
+    def __len__(self) -> int:
+        return len(self._comments)
+
+    def __getitem__(self, index: int) -> str:
+        return self._comments[index]
+
+    def __setitem__(self, index: int, new_comment: str) -> None:
+        self._comments[index] = new_comment
+
+    def __add__(self, other: GameNodeComment) -> GameNodeComment:
+        return GameNodeComment(self._comments + other._comments)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, str):
+            return len(self) == 1 and self[0] == other
+        elif isinstance(other, list):
+            return self._comments == other
+        elif isinstance(other, GameNodeComment):
+            return self._comments == other._comments
+        else:
+            return False
+
+
 class GameNode(abc.ABC):
     parent: Optional[GameNode]
     """The parent node or ``None`` if this is the root node of the game."""
@@ -197,24 +261,24 @@ class GameNode(abc.ABC):
     variations: List[ChildNode]
     """A list of child nodes."""
 
-    comment: list[str]
+    comment: GameNodeComment
     """
     A comment that goes behind the move leading to this node. Comments
     that occur before any moves are assigned to the root node.
     """
 
-    starting_comment: list[str]
+    starting_comment: GameNodeComment
     nags: Set[int]
 
     def __init__(self, *, comment: Union[str, list[str]] = "") -> None:
         self.parent = None
         self.move = None
         self.variations = []
-        self.comment = comment if isinstance(comment, list) else [comment] if comment else []
+        self.comment = GameNodeComment(comment)
 
         # Deprecated: These should be properties of ChildNode, but need to
         # remain here for backwards compatibility.
-        self.starting_comment: list[str] = []
+        self.starting_comment = GameNodeComment()
         self.nags = set()
 
     @abc.abstractmethod
@@ -436,7 +500,7 @@ class GameNode(abc.ABC):
             else:
                 node.comment.extend(comment)
         else:
-            node.comment = comment if isinstance(comment, list) else [comment] if comment else []
+            node.comment.set(comment)
 
         node.nags.update(nags)
 
@@ -449,7 +513,7 @@ class GameNode(abc.ABC):
 
         Complexity is `O(n)`.
         """
-        match = EVAL_REGEX.search(" ".join(self.comment))
+        match = EVAL_REGEX.search(self.comment.join(" "))
         if not match:
             return None
 
@@ -475,7 +539,7 @@ class GameNode(abc.ABC):
 
         Complexity is `O(1)`.
         """
-        match = EVAL_REGEX.search(" ".join(self.comment))
+        match = EVAL_REGEX.search(self.comment.join(" "))
         return int(match.group("depth")) if match and match.group("depth") else None
 
     def set_eval(self, score: Optional[chess.engine.PovScore], depth: Optional[int] = None) -> None:
@@ -498,7 +562,7 @@ class GameNode(abc.ABC):
             if found:
                 break
 
-        self.comment = list(filter(None, self.comment))
+        self.comment.remove_empty()
 
         if not found and eval:
             self.comment.append(eval)
@@ -511,7 +575,7 @@ class GameNode(abc.ABC):
         Returns a list of :class:`arrows <chess.svg.Arrow>`.
         """
         arrows = []
-        for match in ARROWS_REGEX.finditer(" ".join(self.comment)):
+        for match in ARROWS_REGEX.finditer(self.comment.join(" ")):
             for group in match.group("arrows").split(","):
                 arrows.append(chess.svg.Arrow.from_pgn(group))
 
@@ -536,7 +600,7 @@ class GameNode(abc.ABC):
         for index in range(len(self.comment)):
             self.comment[index] = ARROWS_REGEX.sub(_condense_affix(""), self.comment[index])
 
-        self.comment = list(filter(None, self.comment))
+        self.comment.remove_empty()
 
         prefix = ""
         if csl:
@@ -555,7 +619,7 @@ class GameNode(abc.ABC):
         Returns the player's remaining time to the next time control after this
         move, in seconds.
         """
-        match = CLOCK_REGEX.search(" ".join(self.comment))
+        match = CLOCK_REGEX.search(self.comment.join(" "))
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))
@@ -580,7 +644,7 @@ class GameNode(abc.ABC):
             if found:
                 break
 
-        self.comment = list(filter(None, self.comment))
+        self.comment.remove_empty()
 
         if not found and clk:
             self.comment.append(clk)
@@ -593,7 +657,7 @@ class GameNode(abc.ABC):
         Returns the player's elapsed move time use for the comment of this
         move, in seconds.
         """
-        match = EMT_REGEX.search(" ".join(self.comment))
+        match = EMT_REGEX.search(self.comment.join(" "))
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))
@@ -618,7 +682,7 @@ class GameNode(abc.ABC):
             if found:
                 break
 
-        self.comment = list(filter(None, self.comment))
+        self.comment.remove_empty()
 
         if not found and emt:
             self.comment.append(emt)
@@ -677,7 +741,7 @@ class ChildNode(GameNode):
     move: chess.Move
     """The move leading to this node."""
 
-    starting_comment: list[str]
+    starting_comment: GameNodeComment
     """
     A comment for the start of a variation. Only nodes that
     actually start a variation (:func:`~chess.pgn.GameNode.starts_variation()`
@@ -698,7 +762,7 @@ class ChildNode(GameNode):
         self.parent.variations.append(self)
 
         self.nags.update(nags)
-        self.starting_comment = starting_comment if isinstance(starting_comment, list) else [starting_comment] if starting_comment else []
+        self.starting_comment = GameNodeComment(starting_comment)
 
     def board(self) -> chess.Board:
         stack: List[chess.Move] = []
@@ -1150,7 +1214,7 @@ class BaseVisitor(abc.ABC, Generic[ResultT]):
         """
         pass
 
-    def visit_comment(self, comment: list[str]) -> None:
+    def visit_comment(self, comment: GameNodeComment) -> None:
         """Called for each comment."""
         pass
 
@@ -1204,7 +1268,7 @@ class GameBuilder(BaseVisitor[GameT]):
         self.game: GameT = self.Game()
 
         self.variation_stack: List[GameNode] = [self.game]
-        self.starting_comment: list[str] = []
+        self.starting_comment = GameNodeComment()
         self.in_variation = False
 
     def begin_headers(self) -> Headers:
@@ -1229,22 +1293,24 @@ class GameBuilder(BaseVisitor[GameT]):
         if self.game.headers.get("Result", "*") == "*":
             self.game.headers["Result"] = result
 
-    def visit_comment(self, comment: list[str]) -> None:
+    def visit_comment(self, comment: GameNodeComment) -> None:
         if self.in_variation or (self.variation_stack[-1].parent is None and self.variation_stack[-1].is_end()):
             # Add as a comment for the current node if in the middle of
             # a variation. Add as a comment for the game if the comment
             # starts before any move.
             new_comment = self.variation_stack[-1].comment + comment
-            self.variation_stack[-1].comment = list(filter(None, new_comment))
+            new_comment.remove_empty()
+            self.variation_stack[-1].comment = new_comment
         else:
             # Otherwise, it is a starting comment.
             new_comment = self.starting_comment + comment
-            self.starting_comment = list(filter(None, new_comment))
+            new_comment.remove_empty()
+            self.starting_comment = new_comment
 
     def visit_move(self, board: chess.Board, move: chess.Move) -> None:
         self.variation_stack[-1] = self.variation_stack[-1].add_variation(move)
         self.variation_stack[-1].starting_comment = self.starting_comment
-        self.starting_comment = []
+        self.starting_comment = GameNodeComment()
         self.in_variation = True
 
     def handle_error(self, error: Exception) -> None:
@@ -1412,9 +1478,9 @@ class StringExporterMixin:
             self.write_token(") ")
             self.force_movenumber = True
 
-    def visit_comment(self, comment: list[str]) -> None:
+    def visit_comment(self, comment: GameNodeComment) -> None:
         if self.comments and (self.variations or not self.variation_depth):
-            self.write_token(" ".join("{ " + single_comment.replace("}", "").strip() + " }" for single_comment in comment) + " ")
+            self.write_token(comment.pgn_format() + " ")
             self.force_movenumber = True
 
     def visit_nag(self, nag: int) -> None:
@@ -1709,7 +1775,7 @@ def read_game(handle: TextIO, *, Visitor: Any = GameBuilder) -> Any:
                     line = line[close_index + 1:]
 
                 if not skip_variation_depth:
-                    visitor.visit_comment(["".join(comment_lines)])
+                    visitor.visit_comment(GameNodeComment("".join(comment_lines)))
 
                 # Continue with the current line.
                 fresh_line = False

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -1415,8 +1415,8 @@ class StringExporterMixin:
     def visit_comment(self, comment: Union[str, list[str]]) -> None:
         if self.comments and (self.variations or not self.variation_depth):
             def pgn_format(comments: list[str]) -> str:
-                comments = map(lambda s: s.replace("{", ""), comments)
-                comments = map(lambda s: s.replace("}", ""), comments)
+                comments = list(map(lambda s: s.replace("{", ""), comments))
+                comments = list(map(lambda s: s.replace("}", ""), comments))
                 return " ".join(f"{{ {comment} }}" for comment in comments if comment)
 
             comments = _standardize_comments(comment)

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -190,7 +190,9 @@ class GameNodeComment:
 
     A class that can hold one or more comments for a GameNode.
     """
+
     def __init__(self, comment: Union[str, list[str]] = ""):
+        """Create a new comment."""
         self.set(comment)
 
     def set(self, new_comment: Union[str, list[str]]) -> None:
@@ -224,18 +226,23 @@ class GameNodeComment:
         self._comments.pop(index)
 
     def __len__(self) -> int:
+        """Get the number of comments in this node."""
         return len(self._comments)
 
     def __getitem__(self, index: int) -> str:
+        """Get the comment at the given index."""
         return self._comments[index]
 
     def __setitem__(self, index: int, new_comment: str) -> None:
+        """Change the comment at the given index."""
         self._comments[index] = new_comment
 
     def __iter__(self) -> Iterator[str]:
+        """Return an iterator over all comments."""
         return iter(self._comments)
 
     def __add__(self, other: Union[str, list[str], GameNodeComment]) -> GameNodeComment:
+        """Create a new comment set by adding two comment sets with +."""
         if isinstance(other, GameNodeComment):
             return GameNodeComment(self._comments + other._comments)
         else:
@@ -244,6 +251,7 @@ class GameNodeComment:
             return new_node_comment
 
     def __eq__(self, other: object) -> bool:
+        """Check for equality between two comment sets."""
         if isinstance(other, str):
             return (len(self) == 1 and self[0] == other) or (not self and not other)
         elif isinstance(other, list):
@@ -254,9 +262,11 @@ class GameNodeComment:
             return False
 
     def __repr__(self) -> str:
+        """Return a code-like representation of the class."""
         return f"{self.__class__.__name__}({self._comments})"
 
     def __str__(self) -> str:
+        """Return a string representation of the comments in PGN format."""
         return self.pgn_format()
 
 
@@ -289,7 +299,6 @@ class GameNode(abc.ABC):
             self._comment = new_comment
         else:
             self._comment = GameNodeComment(new_comment)
-
 
     _starting_comment: GameNodeComment
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -491,16 +491,7 @@ class GameNode(abc.ABC):
             elif score.white().mate():
                 eval = f"[%eval #{score.white().mate()}{depth_suffix}]"
 
-        found = 0
-        for index in range(len(self.comments)):
-            self.comments[index], found = EVAL_REGEX.subn(_condense_affix(eval), self.comments[index], count=1)
-            if found:
-                break
-
-        self.comments = list(filter(None, self.comments))
-
-        if not found and eval:
-            self.comments.append(eval)
+        self._replace_or_add_annotation(eval, EVAL_REGEX)
 
     def arrows(self) -> List[chess.svg.Arrow]:
         """
@@ -573,16 +564,7 @@ class GameNode(abc.ABC):
             seconds_part = f"{seconds:06.3f}".rstrip("0").rstrip(".")
             clk = f"[%clk {hours:d}:{minutes:02d}:{seconds_part}]"
 
-        found = 0
-        for index in range(len(self.comments)):
-            self.comments[index], found = CLOCK_REGEX.subn(_condense_affix(clk), self.comments[index], count=1)
-            if found:
-                break
-
-        self.comments = list(filter(None, self.comments))
-
-        if not found and clk:
-            self.comments.append(clk)
+        self._replace_or_add_annotation(clk, CLOCK_REGEX)
 
     def emt(self) -> Optional[float]:
         """
@@ -611,16 +593,19 @@ class GameNode(abc.ABC):
             seconds_part = f"{seconds:06.3f}".rstrip("0").rstrip(".")
             emt = f"[%emt {hours:d}:{minutes:02d}:{seconds_part}]"
 
+        self._replace_or_add_annotation(emt, EMT_REGEX)
+
+    def _replace_or_add_annotation(self, text: str, regex: re.Pattern[str]) -> None:
         found = 0
         for index in range(len(self.comments)):
-            self.comments[index], found = EMT_REGEX.subn(_condense_affix(emt), self.comments[index], count=1)
+            self.comments[index], found = regex.subn(_condense_affix(text), self.comments[index], count=1)
             if found:
                 break
 
         self.comments = list(filter(None, self.comments))
 
-        if not found and emt:
-            self.comments.append(emt)
+        if not found and text:
+            self.comments.append(text)
 
     @abc.abstractmethod
     def accept(self, visitor: BaseVisitor[ResultT]) -> ResultT:

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -197,24 +197,24 @@ class GameNode(abc.ABC):
     variations: List[ChildNode]
     """A list of child nodes."""
 
-    comment: str
+    comments: list[str]
     """
-    A comment that goes behind the move leading to this node. Comments
+    Comments that go behind the move leading to this node. Comments
     that occur before any moves are assigned to the root node.
     """
 
-    starting_comment: str
+    starting_comments: list[str]
     nags: Set[int]
 
-    def __init__(self, *, comment: str = "") -> None:
+    def __init__(self, *, comment: Union[str, list[str]] = "") -> None:
         self.parent = None
         self.move = None
         self.variations = []
-        self.comment = comment
+        self.comment = comment if isinstance(comment, list) else [comment] if comment else []
 
         # Deprecated: These should be properties of ChildNode, but need to
         # remain here for backwards compatibility.
-        self.starting_comment = ""
+        self.starting_comment: list[str] = []
         self.nags = set()
 
     @abc.abstractmethod
@@ -386,7 +386,7 @@ class GameNode(abc.ABC):
         """Removes a variation."""
         self.variations.remove(self.variation(move))
 
-    def add_variation(self, move: chess.Move, *, comment: str = "", starting_comment: str = "", nags: Iterable[int] = []) -> ChildNode:
+    def add_variation(self, move: chess.Move, *, comment: Union[str, list[str]] = "", starting_comment: Union[str, list[str]] = "", nags: Iterable[int] = []) -> ChildNode:
         """Creates a child node with the given attributes."""
         # Instanciate ChildNode only in this method.
         return ChildNode(self, move, comment=comment, starting_comment=starting_comment, nags=nags)
@@ -417,7 +417,7 @@ class GameNode(abc.ABC):
         """Returns an iterable over the main moves after this node."""
         return Mainline(self, lambda node: node.move)
 
-    def add_line(self, moves: Iterable[chess.Move], *, comment: str = "", starting_comment: str = "", nags: Iterable[int] = []) -> GameNode:
+    def add_line(self, moves: Iterable[chess.Move], *, comment: Union[str, list[str]] = "", starting_comment: Union[str, list[str]] = "", nags: Iterable[int] = []) -> GameNode:
         """
         Creates a sequence of child nodes for the given list of moves.
         Adds *comment* and *nags* to the last node of the line and returns it.
@@ -431,9 +431,12 @@ class GameNode(abc.ABC):
 
         # Merge comment and NAGs.
         if node.comment:
-            node.comment += " " + comment
+            if isinstance(comment, str):
+                node.comment.append(comment)
+            else:
+                node.comment.extend(comment)
         else:
-            node.comment = comment
+            node.comment = comment if isinstance(comment, list) else [comment] if comment else []
 
         node.nags.update(nags)
 
@@ -446,7 +449,7 @@ class GameNode(abc.ABC):
 
         Complexity is `O(n)`.
         """
-        match = EVAL_REGEX.search(self.comment)
+        match = EVAL_REGEX.search(" ".join(self.comment))
         if not match:
             return None
 
@@ -472,7 +475,7 @@ class GameNode(abc.ABC):
 
         Complexity is `O(1)`.
         """
-        match = EVAL_REGEX.search(self.comment)
+        match = EVAL_REGEX.search(" ".join(self.comment))
         return int(match.group("depth")) if match and match.group("depth") else None
 
     def set_eval(self, score: Optional[chess.engine.PovScore], depth: Optional[int] = None) -> None:
@@ -489,12 +492,16 @@ class GameNode(abc.ABC):
             elif score.white().mate():
                 eval = f"[%eval #{score.white().mate()}{depth_suffix}]"
 
-        self.comment, found = EVAL_REGEX.subn(_condense_affix(eval), self.comment, count=1)
+        found = 0
+        for index in range(len(self.comment)):
+            self.comment[index], found = EVAL_REGEX.subn(_condense_affix(eval), self.comment[index], count=1)
+            if found:
+                break
+
+        self.comment = list(filter(None, self.comment))
 
         if not found and eval:
-            if self.comment and not self.comment.endswith(" "):
-                self.comment += " "
-            self.comment += eval
+            self.comment.append(eval)
 
     def arrows(self) -> List[chess.svg.Arrow]:
         """
@@ -504,7 +511,7 @@ class GameNode(abc.ABC):
         Returns a list of :class:`arrows <chess.svg.Arrow>`.
         """
         arrows = []
-        for match in ARROWS_REGEX.finditer(self.comment):
+        for match in ARROWS_REGEX.finditer(" ".join(self.comment)):
             for group in match.group("arrows").split(","):
                 arrows.append(chess.svg.Arrow.from_pgn(group))
 
@@ -526,7 +533,10 @@ class GameNode(abc.ABC):
                 pass
             (csl if arrow.tail == arrow.head else cal).append(arrow.pgn())  # type: ignore
 
-        self.comment = ARROWS_REGEX.sub(_condense_affix(""), self.comment)
+        for index in range(len(self.comment)):
+            self.comment[index] = ARROWS_REGEX.sub(_condense_affix(""), self.comment[index])
+
+        self.comment = list(filter(None, self.comment))
 
         prefix = ""
         if csl:
@@ -534,10 +544,8 @@ class GameNode(abc.ABC):
         if cal:
             prefix += f"[%cal {','.join(cal)}]"
 
-        if prefix and self.comment and not self.comment.startswith(" ") and not self.comment.startswith("\n"):
-            self.comment = prefix + " " + self.comment
-        else:
-            self.comment = prefix + self.comment
+        if prefix:
+            self.comment.insert(0, prefix)
 
     def clock(self) -> Optional[float]:
         """
@@ -547,7 +555,7 @@ class GameNode(abc.ABC):
         Returns the player's remaining time to the next time control after this
         move, in seconds.
         """
-        match = CLOCK_REGEX.search(self.comment)
+        match = CLOCK_REGEX.search(" ".join(self.comment))
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))
@@ -566,12 +574,16 @@ class GameNode(abc.ABC):
             seconds_part = f"{seconds:06.3f}".rstrip("0").rstrip(".")
             clk = f"[%clk {hours:d}:{minutes:02d}:{seconds_part}]"
 
-        self.comment, found = CLOCK_REGEX.subn(_condense_affix(clk), self.comment, count=1)
+        found = 0
+        for index in range(len(self.comment)):
+            self.comment[index], found = CLOCK_REGEX.subn(_condense_affix(clk), self.comment[index], count=1)
+            if found:
+                break
+
+        self.comment = list(filter(None, self.comment))
 
         if not found and clk:
-            if self.comment and not self.comment.endswith(" ") and not self.comment.endswith("\n"):
-                self.comment += " "
-            self.comment += clk
+            self.comment.append(clk)
 
     def emt(self) -> Optional[float]:
         """
@@ -581,7 +593,7 @@ class GameNode(abc.ABC):
         Returns the player's elapsed move time use for the comment of this
         move, in seconds.
         """
-        match = EMT_REGEX.search(self.comment)
+        match = EMT_REGEX.search(" ".join(self.comment))
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))
@@ -600,12 +612,16 @@ class GameNode(abc.ABC):
             seconds_part = f"{seconds:06.3f}".rstrip("0").rstrip(".")
             emt = f"[%emt {hours:d}:{minutes:02d}:{seconds_part}]"
 
-        self.comment, found = EMT_REGEX.subn(_condense_affix(emt), self.comment, count=1)
+        found = 0
+        for index in range(len(self.comment)):
+            self.comment[index], found = EMT_REGEX.subn(_condense_affix(emt), self.comment[index], count=1)
+            if found:
+                break
+
+        self.comment = list(filter(None, self.comment))
 
         if not found and emt:
-            if self.comment and not self.comment.endswith(" ") and not self.comment.endswith("\n"):
-                self.comment += " "
-            self.comment += emt
+            self.comment.append(emt)
 
     @abc.abstractmethod
     def accept(self, visitor: BaseVisitor[ResultT]) -> ResultT:
@@ -661,7 +677,7 @@ class ChildNode(GameNode):
     move: chess.Move
     """The move leading to this node."""
 
-    starting_comment: str
+    starting_comment: list[str]
     """
     A comment for the start of a variation. Only nodes that
     actually start a variation (:func:`~chess.pgn.GameNode.starts_variation()`
@@ -675,14 +691,14 @@ class ChildNode(GameNode):
     node of the game will never have NAGs.
     """
 
-    def __init__(self, parent: GameNode, move: chess.Move, *, comment: str = "", starting_comment: str = "", nags: Iterable[int] = []) -> None:
+    def __init__(self, parent: GameNode, move: chess.Move, *, comment: Union[str, list[str]] = "", starting_comment: Union[str, list[str]] = "", nags: Iterable[int] = []) -> None:
         super().__init__(comment=comment)
         self.parent = parent
         self.move = move
         self.parent.variations.append(self)
 
         self.nags.update(nags)
-        self.starting_comment = starting_comment
+        self.starting_comment = starting_comment if isinstance(starting_comment, list) else [starting_comment] if starting_comment else []
 
     def board(self) -> chess.Board:
         stack: List[chess.Move] = []
@@ -1134,7 +1150,7 @@ class BaseVisitor(abc.ABC, Generic[ResultT]):
         """
         pass
 
-    def visit_comment(self, comment: str) -> None:
+    def visit_comment(self, comment: list[str]) -> None:
         """Called for each comment."""
         pass
 
@@ -1188,7 +1204,7 @@ class GameBuilder(BaseVisitor[GameT]):
         self.game: GameT = self.Game()
 
         self.variation_stack: List[GameNode] = [self.game]
-        self.starting_comment = ""
+        self.starting_comment: list[str] = []
         self.in_variation = False
 
     def begin_headers(self) -> Headers:
@@ -1213,22 +1229,22 @@ class GameBuilder(BaseVisitor[GameT]):
         if self.game.headers.get("Result", "*") == "*":
             self.game.headers["Result"] = result
 
-    def visit_comment(self, comment: str) -> None:
+    def visit_comment(self, comment: list[str]) -> None:
         if self.in_variation or (self.variation_stack[-1].parent is None and self.variation_stack[-1].is_end()):
             # Add as a comment for the current node if in the middle of
             # a variation. Add as a comment for the game if the comment
             # starts before any move.
-            new_comment = [self.variation_stack[-1].comment, comment]
-            self.variation_stack[-1].comment = " ".join(filter(None, new_comment))
+            new_comment = self.variation_stack[-1].comment + comment
+            self.variation_stack[-1].comment = list(filter(None, new_comment))
         else:
             # Otherwise, it is a starting comment.
-            new_comment = [self.starting_comment, comment]
-            self.starting_comment = " ".join(filter(None, new_comment))
+            new_comment = self.starting_comment + comment
+            self.starting_comment = list(filter(None, new_comment))
 
     def visit_move(self, board: chess.Board, move: chess.Move) -> None:
         self.variation_stack[-1] = self.variation_stack[-1].add_variation(move)
         self.variation_stack[-1].starting_comment = self.starting_comment
-        self.starting_comment = ""
+        self.starting_comment = []
         self.in_variation = True
 
     def handle_error(self, error: Exception) -> None:
@@ -1396,9 +1412,9 @@ class StringExporterMixin:
             self.write_token(") ")
             self.force_movenumber = True
 
-    def visit_comment(self, comment: str) -> None:
+    def visit_comment(self, comment: list[str]) -> None:
         if self.comments and (self.variations or not self.variation_depth):
-            self.write_token("{ " + comment.replace("}", "").strip() + " } ")
+            self.write_token(" ".join("{ " + single_comment.replace("}", "").strip() + " }" for single_comment in comment) + " ")
             self.force_movenumber = True
 
     def visit_nag(self, nag: int) -> None:
@@ -1693,7 +1709,7 @@ def read_game(handle: TextIO, *, Visitor: Any = GameBuilder) -> Any:
                     line = line[close_index + 1:]
 
                 if not skip_variation_depth:
-                    visitor.visit_comment("".join(comment_lines))
+                    visitor.visit_comment(["".join(comment_lines)])
 
                 # Continue with the current line.
                 fresh_line = False

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -306,7 +306,10 @@ class GameNode(abc.ABC):
 
     @comments.setter
     def comments(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        self.comment = new_comment
+        if isinstance(new_comment, GameNodeComment):
+            self._comment = new_comment
+        else:
+            self._comment = GameNodeComment(new_comment)
 
     _starting_comment: GameNodeComment
 
@@ -327,7 +330,10 @@ class GameNode(abc.ABC):
 
     @starting_comments.setter
     def starting_comments(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        self._starting_comment = new_comment
+        if isinstance(new_comment, GameNodeComment):
+            self._starting_comment = new_comment
+        else:
+            self._starting_comment = GameNodeComment(new_comment)
 
     nags: Set[int]
 
@@ -335,11 +341,11 @@ class GameNode(abc.ABC):
         self.parent = None
         self.move = None
         self.variations = []
-        self.comment = GameNodeComment(comment)
+        self.comments = GameNodeComment(comment)
 
         # Deprecated: These should be properties of ChildNode, but need to
         # remain here for backwards compatibility.
-        self.starting_comment = GameNodeComment()
+        self.starting_comments = GameNodeComment()
         self.nags = set()
 
     @abc.abstractmethod
@@ -804,8 +810,8 @@ class ChildNode(GameNode):
     """
 
     @property
-    def starting_comment(self) -> GameNodeComment:
-        return self._starting_comment
+    def starting_comment(self) -> str:
+        return " ".join(self._starting_comment)
 
     @starting_comment.setter
     def starting_comment(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
@@ -827,7 +833,7 @@ class ChildNode(GameNode):
         self.parent.variations.append(self)
 
         self.nags.update(nags)
-        self.starting_comment = GameNodeComment(starting_comment)
+        self.starting_comments = GameNodeComment(starting_comment)
 
     def board(self) -> chess.Board:
         stack: List[chess.Move] = []
@@ -1374,7 +1380,7 @@ class GameBuilder(BaseVisitor[GameT]):
 
     def visit_move(self, board: chess.Board, move: chess.Move) -> None:
         self.variation_stack[-1] = self.variation_stack[-1].add_variation(move)
-        self.variation_stack[-1].starting_comment = self.starting_comment
+        self.variation_stack[-1].starting_comments = self.starting_comment
         self.starting_comment = GameNodeComment()
         self.in_variation = True
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -199,10 +199,9 @@ class GameNodeComment:
 
     def pgn_format(self) -> str:
         """Create a string representation of the comments in PGN format."""
-        comments = list(map(lambda s: s.replace("{", ""), self._comments))
-        comments = list(map(lambda s: s.replace("}", "").strip(), comments))
-        comments = list(filter(None, comments))
-        return "{ " + " } { ".join(comments) + " }"
+        comments = map(lambda s: s.replace("{", ""), self._comments)
+        comments = map(lambda s: s.replace("}", "").strip(), comments)
+        return " ".join(f"{{ {comment} }}" for comment in comments if comment)
 
     def remove_empty(self) -> None:
         """Remove empty comments from the comment list."""

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -193,7 +193,7 @@ class GameNodeComment:
     def __init__(self, comment: Union[str, list[str]] = ""):
         self.set(comment)
 
-    def set(self, new_comment: Union[str, list[str]]):
+    def set(self, new_comment: Union[str, list[str]]) -> None:
         """Replace the comment with a new comment or a list of comments."""
         self._comments = new_comment if isinstance(new_comment, list) else [new_comment] if new_comment else []
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -251,6 +251,12 @@ class GameNodeComment:
         else:
             return False
 
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._comments})"
+
+    def __str__(self) -> str:
+        return self.pgn_format()
+
 
 class GameNode(abc.ABC):
     parent: Optional[GameNode]

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -705,7 +705,7 @@ class GameNode(abc.ABC):
         Returns the player's elapsed move time use for the comment of this
         move, in seconds.
         """
-        match = EMT_REGEX.search(" ".join(self.comments))
+        match = EMT_REGEX.search(self.comment)
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -199,7 +199,7 @@ class GameNode(abc.ABC):
 
     comment: list[str]
     """
-    Comments that go behind the move leading to this node. Comments
+    A comment that goes behind the move leading to this node. Comments
     that occur before any moves are assigned to the root node.
     """
 

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -220,6 +220,10 @@ class GameNodeComment:
         """Insert a new comment before the specified index."""
         self._comments.insert(index, new_comment)
 
+    def pop(self, index: int = -1) -> None:
+        """Delete comment at the given index (default is the last comment)."""
+        self._comments.pop(index)
+
     def join(self, joiner: str) -> str:
         """Join all of the comments together with a joiner string between each."""
         return joiner.join(self._comments)

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -223,10 +223,6 @@ class GameNodeComment:
         """Delete comment at the given index (default is the last comment)."""
         self._comments.pop(index)
 
-    def join(self, joiner: str) -> str:
-        """Join all of the comments together with a joiner string between each."""
-        return joiner.join(self._comments)
-
     def __len__(self) -> int:
         return len(self._comments)
 
@@ -235,6 +231,9 @@ class GameNodeComment:
 
     def __setitem__(self, index: int, new_comment: str) -> None:
         self._comments[index] = new_comment
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._comments)
 
     def __add__(self, other: Union[str, list[str], GameNodeComment]) -> GameNodeComment:
         if isinstance(other, GameNodeComment):
@@ -543,7 +542,7 @@ class GameNode(abc.ABC):
 
         Complexity is `O(n)`.
         """
-        match = EVAL_REGEX.search(self.comment.join(" "))
+        match = EVAL_REGEX.search(" ".join(self.comment))
         if not match:
             return None
 
@@ -569,7 +568,7 @@ class GameNode(abc.ABC):
 
         Complexity is `O(1)`.
         """
-        match = EVAL_REGEX.search(self.comment.join(" "))
+        match = EVAL_REGEX.search(" ".join(self.comment))
         return int(match.group("depth")) if match and match.group("depth") else None
 
     def set_eval(self, score: Optional[chess.engine.PovScore], depth: Optional[int] = None) -> None:
@@ -605,7 +604,7 @@ class GameNode(abc.ABC):
         Returns a list of :class:`arrows <chess.svg.Arrow>`.
         """
         arrows = []
-        for match in ARROWS_REGEX.finditer(self.comment.join(" ")):
+        for match in ARROWS_REGEX.finditer(" ".join(self.comment)):
             for group in match.group("arrows").split(","):
                 arrows.append(chess.svg.Arrow.from_pgn(group))
 
@@ -649,7 +648,7 @@ class GameNode(abc.ABC):
         Returns the player's remaining time to the next time control after this
         move, in seconds.
         """
-        match = CLOCK_REGEX.search(self.comment.join(" "))
+        match = CLOCK_REGEX.search(" ".join(self.comment))
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))
@@ -687,7 +686,7 @@ class GameNode(abc.ABC):
         Returns the player's elapsed move time use for the comment of this
         move, in seconds.
         """
-        match = EMT_REGEX.search(self.comment.join(" "))
+        match = EMT_REGEX.search(" ".join(self.comment))
         if match is None:
             return None
         return int(match.group("hours")) * 3600 + int(match.group("minutes")) * 60 + float(match.group("seconds"))

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -1400,9 +1400,8 @@ class StringExporterMixin:
     def visit_comment(self, comment: Union[str, list[str]]) -> None:
         if self.comments and (self.variations or not self.variation_depth):
             def pgn_format(comments: list[str]) -> str:
-                comments = list(map(lambda s: s.replace("{", ""), comments))
-                comments = list(map(lambda s: s.replace("}", ""), comments))
-                return " ".join(f"{{ {comment} }}" for comment in comments if comment)
+                edit = map(lambda s: s.replace("{", "").replace("}", ""), comments)
+                return " ".join(f"{{ {comment} }}" for comment in edit if comment)
 
             comments = _standardize_comments(comment)
             self.write_token(pgn_format(comments) + " ")

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -234,12 +234,12 @@ class GameNodeComment:
         self._comments[index] = new_comment
 
     def __add__(self, other: Union[str, list[str], GameNodeComment]) -> GameNodeComment:
-        if not isinstance(other, GameNodeComment):
-            new_node_comment = GameNodeComment(self._comments)
+        if isinstance(other, GameNodeComment):
+            return GameNodeComment(self._comments + other._comments)
+        else:
+            new_node_comment = GameNodeComment(self._comments.copy())
             new_node_comment.append(other)
             return new_node_comment
-        else:
-            return GameNodeComment(self._comments + other._comments)
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, str):

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -209,13 +209,13 @@ class GameNodeComment:
         """Remove empty comments from the comment list."""
         self._comments = list(filter(None, self._comments))
 
-    def append(self, new_comment: str) -> None:
-        """Append a new comment to the end of the comment list."""
-        self._comments.append(new_comment)
-
-    def extend(self, new_comments: list[str]) -> None:
-        """Append several new comments to the end of the comment list."""
-        self._comments.extend(new_comments)
+    def append(self, new_comment: Union[str, list[str]]) -> None:
+        """Append one or more new comments to the end of the comment list."""
+        if new_comment:
+            if isinstance(new_comment, str):
+                self._comments.append(new_comment)
+            else:
+                self._comments.extend(new_comment)
 
     def insert(self, index: int, new_comment: str) -> None:
         """Insert a new comment before the specified index."""
@@ -494,14 +494,7 @@ class GameNode(abc.ABC):
             starting_comment = ""
 
         # Merge comment and NAGs.
-        if node.comment:
-            if isinstance(comment, str):
-                node.comment.append(comment)
-            else:
-                node.comment.extend(comment)
-        else:
-            node.comment.set(comment)
-
+        node.comment.append(comment)
         node.nags.update(nags)
 
         return node

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -191,9 +191,9 @@ class GameNodeComment:
     A class that can hold one or more comments for a GameNode.
     """
 
-    def __init__(self, comment: Union[str, list[str]] = ""):
+    def __init__(self, comment: Union[str, list[str], GameNodeComment] = ""):
         """Create a new comment."""
-        self.set(comment)
+        self.set(comment._comments if isinstance(comment,GameNodeComment) else comment)
 
     def set(self, new_comment: Union[str, list[str]]) -> None:
         """Replace the comment with a new comment or a list of comments."""
@@ -295,10 +295,7 @@ class GameNode(abc.ABC):
 
     @comment.setter
     def comment(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        if isinstance(new_comment, GameNodeComment):
-            self._comment = new_comment
-        else:
-            self._comment = GameNodeComment(new_comment)
+        self._comment = GameNodeComment(new_comment)
 
     @property
     def comments(self) -> GameNodeComment:
@@ -306,10 +303,7 @@ class GameNode(abc.ABC):
 
     @comments.setter
     def comments(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        if isinstance(new_comment, GameNodeComment):
-            self._comment = new_comment
-        else:
-            self._comment = GameNodeComment(new_comment)
+        self._comment = GameNodeComment(new_comment)
 
     _starting_comment: GameNodeComment
 
@@ -319,10 +313,7 @@ class GameNode(abc.ABC):
 
     @starting_comment.setter
     def starting_comment(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        if isinstance(new_comment, GameNodeComment):
-            self._starting_comment = new_comment
-        else:
-            self._starting_comment = GameNodeComment(new_comment)
+        self._starting_comment = GameNodeComment(new_comment)
 
     @property
     def starting_comments(self) -> GameNodeComment:
@@ -330,10 +321,7 @@ class GameNode(abc.ABC):
 
     @starting_comments.setter
     def starting_comments(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        if isinstance(new_comment, GameNodeComment):
-            self._starting_comment = new_comment
-        else:
-            self._starting_comment = GameNodeComment(new_comment)
+        self._starting_comment = GameNodeComment(new_comment)
 
     nags: Set[int]
 
@@ -815,10 +803,7 @@ class ChildNode(GameNode):
 
     @starting_comment.setter
     def starting_comment(self, new_comment: Union[str, list[str], GameNodeComment]) -> None:
-        if isinstance(new_comment, GameNodeComment):
-            self._starting_comment = new_comment
-        else:
-            self._starting_comment = GameNodeComment(new_comment)
+        self._starting_comment = GameNodeComment(new_comment)
 
     nags: Set[int]
     """

--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -239,7 +239,7 @@ class GameNodeComment:
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, str):
-            return len(self) == 1 and self[0] == other
+            return (len(self) == 1 and self[0] == other) or (not self and not other)
         elif isinstance(other, list):
             return self._comments == other
         elif isinstance(other, GameNodeComment):

--- a/test.py
+++ b/test.py
@@ -2110,7 +2110,7 @@ class PgnTestCase(unittest.TestCase):
         e4_c5.comments = ["Sicilian"]
 
         e4_d5_exd5 = e4_d5.add_main_variation(e4_d5.board().parse_san("exd5"))
-        e4_d5_exd5.comments = ["Best", "and the end of this example"]
+        e4_d5_exd5.comments = ["Best", "and the end of this {example}"]
 
         # Test string exporter with various options.
         exporter = chess.pgn.StringExporter(headers=False, comments=False, variations=False)

--- a/test.py
+++ b/test.py
@@ -2219,7 +2219,7 @@ class PgnTestCase(unittest.TestCase):
         pgn = io.StringIO("1. e4 {A common opening} 1... e5 {A common response} {An uncommon comment}")
         game = chess.pgn.read_game(pgn)
         first_move = game.variation(0)
-        self.assertEqual(first_move.comment, ["A common opening"])
+        self.assertEqual(first_move.comment, "A common opening")
         second_move = first_move.variation(0)
         self.assertEqual(second_move.comment, ["A common response", "An uncommon comment"])
 
@@ -2237,7 +2237,7 @@ class PgnTestCase(unittest.TestCase):
 
         # Make sure the comment for the second variation is there.
         self.assertIn(5, node[1].nags)
-        self.assertEqual(node[1].comment, ["\n/\\ Ne7, c6"])
+        self.assertEqual(node[1].comment, "\n/\\ Ne7, c6")
 
     def test_promotion_without_equals(self):
         # Example game from https://github.com/rozim/ChessData as originally
@@ -2325,12 +2325,12 @@ class PgnTestCase(unittest.TestCase):
     def test_game_starting_comment(self):
         pgn = io.StringIO("{ Game starting comment } 1. d3")
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, ["Game starting comment"])
+        self.assertEqual(game.comment, "Game starting comment")
         self.assertEqual(game[0].san(), "d3")
 
         pgn = io.StringIO("{ Empty game, but has a comment }")
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, ["Empty game, but has a comment"])
+        self.assertEqual(game.comment, "Empty game, but has a comment")
 
     def test_game_starting_variation(self):
         pgn = io.StringIO(textwrap.dedent("""\
@@ -2338,7 +2338,7 @@ class PgnTestCase(unittest.TestCase):
             """))
 
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, ["Start of game"])
+        self.assertEqual(game.comment, "Start of game")
 
         node = game[0]
         self.assertEqual(node.move, chess.Move.from_uci("e2e4"))
@@ -2348,7 +2348,7 @@ class PgnTestCase(unittest.TestCase):
         node = game[1]
         self.assertEqual(node.move, chess.Move.from_uci("d2d4"))
         self.assertFalse(node.comment)
-        self.assertEqual(node.starting_comment, ["Start of variation"])
+        self.assertEqual(node.starting_comment, "Start of variation")
 
     def test_annotation_symbols(self):
         pgn = io.StringIO("1. b4?! g6 2. Bb2 Nc6? 3. Bxh8!!")
@@ -2693,12 +2693,12 @@ class PgnTestCase(unittest.TestCase):
         tail = game.add_line(moves, starting_comment="start", comment="end", nags=(17, 42))
 
         self.assertEqual(tail.parent.move, chess.Move.from_uci("g1f3"))
-        self.assertEqual(tail.parent.starting_comment, ["start"])
-        self.assertEqual(tail.parent.comment, [])
+        self.assertEqual(tail.parent.starting_comment, "start")
+        self.assertEqual(tail.parent.comment, "")
         self.assertEqual(len(tail.parent.nags), 0)
 
         self.assertEqual(tail.move, chess.Move.from_uci("d7d5"))
-        self.assertEqual(tail.comment, ["end"])
+        self.assertEqual(tail.comment, "end")
         self.assertIn(42, tail.nags)
 
     def test_mainline(self):
@@ -2828,7 +2828,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_annotations(self):
         game = chess.pgn.Game()
-        game.comment = chess.pgn.GameNodeComment("foo [%bar] baz")
+        game.comment.set("foo [%bar] baz")
 
         self.assertTrue(game.clock() is None)
         clock = 12345
@@ -2869,7 +2869,7 @@ class PgnTestCase(unittest.TestCase):
 
         game.set_clock(None)
         game.set_arrows([])
-        self.assertEqual(game.comment, ["foo [%bar] baz"])
+        self.assertEqual(game.comment, "foo [%bar] baz")
 
     def test_eval(self):
         game = chess.pgn.Game()
@@ -2879,15 +2879,15 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_emt(self):
         game = chess.pgn.Game()
-        game.comment = chess.pgn.GameNodeComment("[%emt 0:00:01.234]")
+        game.comment.set("[%emt 0:00:01.234]")
         self.assertEqual(game.emt(), 1.234)
 
         game.set_emt(6.54321)
-        self.assertEqual(game.comment, ["[%emt 0:00:06.543]"])
+        self.assertEqual(game.comment, "[%emt 0:00:06.543]")
         self.assertEqual(game.emt(), 6.543)
 
         game.set_emt(-70)
-        self.assertEqual(game.comment, ["[%emt 0:00:00]"])  # Clamped
+        self.assertEqual(game.comment, "[%emt 0:00:00]")  # Clamped
         self.assertEqual(game.emt(), 0)
 
     def test_float_clk(self):
@@ -2896,11 +2896,11 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(game.clock(), 1.234)
 
         game.set_clock(6.54321)
-        self.assertEqual(game.comment, ["[%clk 0:00:06.543]"])
+        self.assertEqual(game.comment, "[%clk 0:00:06.543]")
         self.assertEqual(game.clock(), 6.543)
 
         game.set_clock(-70)
-        self.assertEqual(game.comment, ["[%clk 0:00:00]"])  # Clamped
+        self.assertEqual(game.comment, "[%clk 0:00:00]")  # Clamped
         self.assertEqual(game.clock(), 0)
 
     def test_node_turn(self):

--- a/test.py
+++ b/test.py
@@ -2100,7 +2100,7 @@ class PgnTestCase(unittest.TestCase):
         e4_c5.comment = ["Sicilian"]
 
         e4_d5_exd5 = e4_d5.add_main_variation(e4_d5.board().parse_san("exd5"))
-        e4_d5_exd5.comment = ["Best"]
+        e4_d5_exd5.comment = ["Best", "and the end of this example"]
 
         # Test string exporter with various options.
         exporter = chess.pgn.StringExporter(headers=False, comments=False, variations=False)
@@ -2125,7 +2125,7 @@ class PgnTestCase(unittest.TestCase):
 
             { Test game: } 1. e4 { Scandinavian Defense: } 1... d5 ( { This } 1... h5 $2
             { is nonsense } ) ( 1... e5 2. Qf3 $2 ) ( 1... c5 { Sicilian } ) 2. exd5
-            { Best } *""")
+            { Best } { and the end of this example } *""")
         self.assertEqual(str(exporter), pgn)
 
         # Test file exporter.

--- a/test.py
+++ b/test.py
@@ -2227,13 +2227,6 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(first_move.comments, ["A common opening"])
         second_move = first_move.variation(0)
         self.assertEqual(second_move.comments, ["A common response", "An uncommon comment"])
-        second_move.comments.pop()
-        self.assertEqual(second_move.comments, ["A common response"])
-        second_move.comments.append("A replaced comment")
-        multiple_comments = ["A common response", "A replaced comment"]
-        self.assertEqual(second_move.comments, multiple_comments)
-        second_move.comments.pop(0)
-        self.assertEqual(second_move.comments, ["A replaced comment"])
 
     def test_comment_at_eol(self):
         pgn = io.StringIO(textwrap.dedent("""\

--- a/test.py
+++ b/test.py
@@ -2222,6 +2222,14 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(first_move.comment, "A common opening")
         second_move = first_move.variation(0)
         self.assertEqual(second_move.comment, ["A common response", "An uncommon comment"])
+        second_move.comment.pop()
+        self.assertEqual(second_move.comment, ["A common response"])
+        self.assertEqual(second_move.comment, "A common response")
+        second_move.comment.append("A replaced comment")
+        self.assertEqual(second_move.comment, ["A common response", "A replaced comment"])
+        second_move.comment.pop(0)
+        self.assertEqual(second_move.comment, ["A replaced comment"])
+        self.assertEqual(second_move.comment, "A replaced comment")
 
     def test_comment_at_eol(self):
         pgn = io.StringIO(textwrap.dedent("""\

--- a/test.py
+++ b/test.py
@@ -2083,29 +2083,29 @@ class PgnTestCase(unittest.TestCase):
 
     def test_exporter(self):
         game = chess.pgn.Game()
-        game.comment = "Test game:"
+        game.comments = ["Test game:"]
         game.headers["Result"] = "*"
         game.headers["VeryLongHeader"] = "This is a very long header, much wider than the 80 columns that PGNs are formatted with by default"
 
         e4 = game.add_variation(game.board().parse_san("e4"))
-        e4.comment = "Scandinavian Defense:"
+        e4.comments = ["Scandinavian Defense:"]
 
         e4_d5 = e4.add_variation(e4.board().parse_san("d5"))
 
         e4_h5 = e4.add_variation(e4.board().parse_san("h5"))
         e4_h5.nags.add(chess.pgn.NAG_MISTAKE)
-        e4_h5.starting_comment = "This"
-        e4_h5.comment = "is nonsense"
+        e4_h5.starting_comments = ["This"]
+        e4_h5.comments = ["is nonsense"]
 
         e4_e5 = e4.add_variation(e4.board().parse_san("e5"))
         e4_e5_Qf3 = e4_e5.add_variation(e4_e5.board().parse_san("Qf3"))
         e4_e5_Qf3.nags.add(chess.pgn.NAG_MISTAKE)
 
         e4_c5 = e4.add_variation(e4.board().parse_san("c5"))
-        e4_c5.comment = "Sicilian"
+        e4_c5.comments = ["Sicilian"]
 
         e4_d5_exd5 = e4_d5.add_main_variation(e4_d5.board().parse_san("exd5"))
-        e4_d5_exd5.comment = ["Best", "and the end of this example"]
+        e4_d5_exd5.comments = ["Best", "and the end of this example"]
 
         # Test string exporter with various options.
         exporter = chess.pgn.StringExporter(headers=False, comments=False, variations=False)
@@ -2224,26 +2224,16 @@ class PgnTestCase(unittest.TestCase):
         pgn = io.StringIO("1. e4 {A common opening} 1... e5 {A common response} {An uncommon comment}")
         game = chess.pgn.read_game(pgn)
         first_move = game.variation(0)
-        self.assertEqual(first_move.comment, "A common opening")
-        self.assertEqual(first_move.comments, "A common opening")
         self.assertEqual(first_move.comments, ["A common opening"])
         second_move = first_move.variation(0)
         self.assertEqual(second_move.comments, ["A common response", "An uncommon comment"])
         second_move.comments.pop()
         self.assertEqual(second_move.comments, ["A common response"])
-        self.assertEqual(second_move.comments, "A common response")
-        self.assertEqual(second_move.comment, "A common response")
         second_move.comments.append("A replaced comment")
         multiple_comments = ["A common response", "A replaced comment"]
         self.assertEqual(second_move.comments, multiple_comments)
-        for move_comment, test_comment in zip(second_move.comments, multiple_comments):
-            self.assertEqual(move_comment, test_comment)
-        self.assertEqual(list(second_move.comments), multiple_comments)
-        self.assertEqual(second_move.comment, " ".join(multiple_comments))
         second_move.comments.pop(0)
         self.assertEqual(second_move.comments, ["A replaced comment"])
-        self.assertEqual(second_move.comments, "A replaced comment")
-        self.assertEqual(second_move.comment, "A replaced comment")
 
     def test_comment_at_eol(self):
         pgn = io.StringIO(textwrap.dedent("""\
@@ -2259,7 +2249,7 @@ class PgnTestCase(unittest.TestCase):
 
         # Make sure the comment for the second variation is there.
         self.assertIn(5, node[1].nags)
-        self.assertEqual(node[1].comment, "\n/\\ Ne7, c6")
+        self.assertEqual(node[1].comments, ["\n/\\ Ne7, c6"])
 
     def test_promotion_without_equals(self):
         # Example game from https://github.com/rozim/ChessData as originally
@@ -2347,12 +2337,12 @@ class PgnTestCase(unittest.TestCase):
     def test_game_starting_comment(self):
         pgn = io.StringIO("{ Game starting comment } 1. d3")
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, "Game starting comment")
+        self.assertEqual(game.comments, ["Game starting comment"])
         self.assertEqual(game[0].san(), "d3")
 
         pgn = io.StringIO("{ Empty game, but has a comment }")
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, "Empty game, but has a comment")
+        self.assertEqual(game.comments, ["Empty game, but has a comment"])
 
     def test_game_starting_variation(self):
         pgn = io.StringIO(textwrap.dedent("""\
@@ -2360,17 +2350,17 @@ class PgnTestCase(unittest.TestCase):
             """))
 
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, "Start of game")
+        self.assertEqual(game.comments, ["Start of game"])
 
         node = game[0]
         self.assertEqual(node.move, chess.Move.from_uci("e2e4"))
-        self.assertFalse(node.comment)
-        self.assertFalse(node.starting_comment)
+        self.assertFalse(node.comments)
+        self.assertFalse(node.starting_comments)
 
         node = game[1]
         self.assertEqual(node.move, chess.Move.from_uci("d2d4"))
-        self.assertFalse(node.comment)
-        self.assertEqual(node.starting_comment, "Start of variation")
+        self.assertFalse(node.comments)
+        self.assertEqual(node.starting_comments, ["Start of variation"])
 
     def test_annotation_symbols(self):
         pgn = io.StringIO("1. b4?! g6 2. Bb2 Nc6? 3. Bxh8!!")
@@ -2715,12 +2705,12 @@ class PgnTestCase(unittest.TestCase):
         tail = game.add_line(moves, starting_comment="start", comment="end", nags=(17, 42))
 
         self.assertEqual(tail.parent.move, chess.Move.from_uci("g1f3"))
-        self.assertEqual(tail.parent.starting_comment, "start")
-        self.assertEqual(tail.parent.comment, "")
+        self.assertEqual(tail.parent.starting_comments, ["start"])
+        self.assertEqual(tail.parent.comments, [])
         self.assertEqual(len(tail.parent.nags), 0)
 
         self.assertEqual(tail.move, chess.Move.from_uci("d7d5"))
-        self.assertEqual(tail.comment, "end")
+        self.assertEqual(tail.comments, ["end"])
         self.assertIn(42, tail.nags)
 
     def test_mainline(self):
@@ -2850,12 +2840,11 @@ class PgnTestCase(unittest.TestCase):
 
     def test_annotations(self):
         game = chess.pgn.Game()
-        game.comment = "foo [%bar] baz"
+        game.comments = ["foo [%bar] baz"]
 
         self.assertTrue(game.clock() is None)
         clock = 12345
         game.set_clock(clock)
-        self.assertEqual(game.comment, "foo [%bar] baz [%clk 3:25:45]")
         self.assertEqual(game.comments, ["foo [%bar] baz", "[%clk 3:25:45]"])
         self.assertEqual(game.clock(), clock)
 
@@ -2872,7 +2861,6 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(game.arrows(), [])
         game.set_arrows([(chess.A1, chess.A1), chess.svg.Arrow(chess.A1, chess.H1, color="red"), chess.svg.Arrow(chess.B1, chess.B8)])
         self.assertEqual(game.comments, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]", "[%eval #1,5]"])
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%eval #1,5]")
         arrows = game.arrows()
         self.assertEqual(len(arrows), 3)
         self.assertEqual(arrows[0].color, "green")
@@ -2883,21 +2871,17 @@ class PgnTestCase(unittest.TestCase):
         emt = 321
         game.set_emt(emt)
         self.assertEqual(game.comments, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]", "[%eval #1,5]", "[%emt 0:05:21]"])
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%eval #1,5] [%emt 0:05:21]")
         self.assertEqual(game.emt(), emt)
 
         game.set_eval(None)
         self.assertEqual(game.comments, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]", "[%emt 0:05:21]"])
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%emt 0:05:21]")
 
         game.set_emt(None)
         self.assertEqual(game.comments, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]"])
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45]")
 
         game.set_clock(None)
         game.set_arrows([])
-        self.assertEqual(game.comments, "foo [%bar] baz")
-        self.assertEqual(game.comment, "foo [%bar] baz")
+        self.assertEqual(game.comments, ["foo [%bar] baz"])
 
     def test_eval(self):
         game = chess.pgn.Game()
@@ -2907,28 +2891,28 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_emt(self):
         game = chess.pgn.Game()
-        game.comment = "[%emt 0:00:01.234]"
+        game.comments = ["[%emt 0:00:01.234]"]
         self.assertEqual(game.emt(), 1.234)
 
         game.set_emt(6.54321)
-        self.assertEqual(game.comment, "[%emt 0:00:06.543]")
+        self.assertEqual(game.comments, ["[%emt 0:00:06.543]"])
         self.assertEqual(game.emt(), 6.543)
 
         game.set_emt(-70)
-        self.assertEqual(game.comment, "[%emt 0:00:00]")  # Clamped
+        self.assertEqual(game.comments, ["[%emt 0:00:00]"])  # Clamped
         self.assertEqual(game.emt(), 0)
 
     def test_float_clk(self):
         game = chess.pgn.Game()
-        game.comment = "[%clk 0:00:01.234]"
+        game.comments = ["[%clk 0:00:01.234]"]
         self.assertEqual(game.clock(), 1.234)
 
         game.set_clock(6.54321)
-        self.assertEqual(game.comment, "[%clk 0:00:06.543]")
+        self.assertEqual(game.comments, ["[%clk 0:00:06.543]"])
         self.assertEqual(game.clock(), 6.543)
 
         game.set_clock(-70)
-        self.assertEqual(game.comment, "[%clk 0:00:00]")  # Clamped
+        self.assertEqual(game.comments, ["[%clk 0:00:00]"])  # Clamped
         self.assertEqual(game.clock(), 0)
 
     def test_node_turn(self):

--- a/test.py
+++ b/test.py
@@ -2226,7 +2226,11 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(second_move.comment, ["A common response"])
         self.assertEqual(second_move.comment, "A common response")
         second_move.comment.append("A replaced comment")
-        self.assertEqual(second_move.comment, ["A common response", "A replaced comment"])
+        multiple_comments = ["A common response", "A replaced comment"]
+        self.assertEqual(second_move.comment, multiple_comments)
+        for move_comment, test_comment in zip(second_move.comment, multiple_comments):
+            self.assertEqual(move_comment, test_comment)
+        self.assertEqual(list(second_move.comment), multiple_comments)
         second_move.comment.pop(0)
         self.assertEqual(second_move.comment, ["A replaced comment"])
         self.assertEqual(second_move.comment, "A replaced comment")

--- a/test.py
+++ b/test.py
@@ -2078,29 +2078,29 @@ class PgnTestCase(unittest.TestCase):
 
     def test_exporter(self):
         game = chess.pgn.Game()
-        game.comment = ["Test game:"]
+        game.comment.set("Test game:")
         game.headers["Result"] = "*"
         game.headers["VeryLongHeader"] = "This is a very long header, much wider than the 80 columns that PGNs are formatted with by default"
 
         e4 = game.add_variation(game.board().parse_san("e4"))
-        e4.comment = ["Scandinavian Defense:"]
+        e4.comment.set("Scandinavian Defense:")
 
         e4_d5 = e4.add_variation(e4.board().parse_san("d5"))
 
         e4_h5 = e4.add_variation(e4.board().parse_san("h5"))
         e4_h5.nags.add(chess.pgn.NAG_MISTAKE)
-        e4_h5.starting_comment = ["This"]
-        e4_h5.comment = ["is nonsense"]
+        e4_h5.starting_comment.set("This")
+        e4_h5.comment.set("is nonsense")
 
         e4_e5 = e4.add_variation(e4.board().parse_san("e5"))
         e4_e5_Qf3 = e4_e5.add_variation(e4_e5.board().parse_san("Qf3"))
         e4_e5_Qf3.nags.add(chess.pgn.NAG_MISTAKE)
 
         e4_c5 = e4.add_variation(e4.board().parse_san("c5"))
-        e4_c5.comment = ["Sicilian"]
+        e4_c5.comment.set("Sicilian")
 
         e4_d5_exd5 = e4_d5.add_main_variation(e4_d5.board().parse_san("exd5"))
-        e4_d5_exd5.comment = ["Best", "and the end of this example"]
+        e4_d5_exd5.comment.set(["Best", "and the end of this example"])
 
         # Test string exporter with various options.
         exporter = chess.pgn.StringExporter(headers=False, comments=False, variations=False)
@@ -2828,7 +2828,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_annotations(self):
         game = chess.pgn.Game()
-        game.comment = ["foo [%bar] baz"]
+        game.comment = chess.pgn.GameNodeComment("foo [%bar] baz")
 
         self.assertTrue(game.clock() is None)
         clock = 12345
@@ -2879,7 +2879,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_emt(self):
         game = chess.pgn.Game()
-        game.comment = ["[%emt 0:00:01.234]"]
+        game.comment = chess.pgn.GameNodeComment("[%emt 0:00:01.234]")
         self.assertEqual(game.emt(), 1.234)
 
         game.set_emt(6.54321)
@@ -2892,7 +2892,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_clk(self):
         game = chess.pgn.Game()
-        game.comment = ["[%clk 0:00:01.234]"]
+        game.comment.set("[%clk 0:00:01.234]")
         self.assertEqual(game.clock(), 1.234)
 
         game.set_clock(6.54321)

--- a/test.py
+++ b/test.py
@@ -2078,29 +2078,29 @@ class PgnTestCase(unittest.TestCase):
 
     def test_exporter(self):
         game = chess.pgn.Game()
-        game.comment = "Test game:"
+        game.comment = ["Test game:"]
         game.headers["Result"] = "*"
         game.headers["VeryLongHeader"] = "This is a very long header, much wider than the 80 columns that PGNs are formatted with by default"
 
         e4 = game.add_variation(game.board().parse_san("e4"))
-        e4.comment = "Scandinavian Defense:"
+        e4.comment = ["Scandinavian Defense:"]
 
         e4_d5 = e4.add_variation(e4.board().parse_san("d5"))
 
         e4_h5 = e4.add_variation(e4.board().parse_san("h5"))
         e4_h5.nags.add(chess.pgn.NAG_MISTAKE)
-        e4_h5.starting_comment = "This"
-        e4_h5.comment = "is nonsense"
+        e4_h5.starting_comment = ["This"]
+        e4_h5.comment = ["is nonsense"]
 
         e4_e5 = e4.add_variation(e4.board().parse_san("e5"))
         e4_e5_Qf3 = e4_e5.add_variation(e4_e5.board().parse_san("Qf3"))
         e4_e5_Qf3.nags.add(chess.pgn.NAG_MISTAKE)
 
         e4_c5 = e4.add_variation(e4.board().parse_san("c5"))
-        e4_c5.comment = "Sicilian"
+        e4_c5.comment = ["Sicilian"]
 
         e4_d5_exd5 = e4_d5.add_main_variation(e4_d5.board().parse_san("exd5"))
-        e4_d5_exd5.comment = "Best"
+        e4_d5_exd5.comment = ["Best"]
 
         # Test string exporter with various options.
         exporter = chess.pgn.StringExporter(headers=False, comments=False, variations=False)
@@ -2229,7 +2229,7 @@ class PgnTestCase(unittest.TestCase):
 
         # Make sure the comment for the second variation is there.
         self.assertIn(5, node[1].nags)
-        self.assertEqual(node[1].comment, "\n/\\ Ne7, c6")
+        self.assertEqual(node[1].comment, ["\n/\\ Ne7, c6"])
 
     def test_promotion_without_equals(self):
         # Example game from https://github.com/rozim/ChessData as originally
@@ -2317,12 +2317,12 @@ class PgnTestCase(unittest.TestCase):
     def test_game_starting_comment(self):
         pgn = io.StringIO("{ Game starting comment } 1. d3")
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, "Game starting comment")
+        self.assertEqual(game.comment, ["Game starting comment"])
         self.assertEqual(game[0].san(), "d3")
 
         pgn = io.StringIO("{ Empty game, but has a comment }")
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, "Empty game, but has a comment")
+        self.assertEqual(game.comment, ["Empty game, but has a comment"])
 
     def test_game_starting_variation(self):
         pgn = io.StringIO(textwrap.dedent("""\
@@ -2330,7 +2330,7 @@ class PgnTestCase(unittest.TestCase):
             """))
 
         game = chess.pgn.read_game(pgn)
-        self.assertEqual(game.comment, "Start of game")
+        self.assertEqual(game.comment, ["Start of game"])
 
         node = game[0]
         self.assertEqual(node.move, chess.Move.from_uci("e2e4"))
@@ -2340,7 +2340,7 @@ class PgnTestCase(unittest.TestCase):
         node = game[1]
         self.assertEqual(node.move, chess.Move.from_uci("d2d4"))
         self.assertFalse(node.comment)
-        self.assertEqual(node.starting_comment, "Start of variation")
+        self.assertEqual(node.starting_comment, ["Start of variation"])
 
     def test_annotation_symbols(self):
         pgn = io.StringIO("1. b4?! g6 2. Bb2 Nc6? 3. Bxh8!!")
@@ -2685,12 +2685,12 @@ class PgnTestCase(unittest.TestCase):
         tail = game.add_line(moves, starting_comment="start", comment="end", nags=(17, 42))
 
         self.assertEqual(tail.parent.move, chess.Move.from_uci("g1f3"))
-        self.assertEqual(tail.parent.starting_comment, "start")
-        self.assertEqual(tail.parent.comment, "")
+        self.assertEqual(tail.parent.starting_comment, ["start"])
+        self.assertEqual(tail.parent.comment, [])
         self.assertEqual(len(tail.parent.nags), 0)
 
         self.assertEqual(tail.move, chess.Move.from_uci("d7d5"))
-        self.assertEqual(tail.comment, "end")
+        self.assertEqual(tail.comment, ["end"])
         self.assertIn(42, tail.nags)
 
     def test_mainline(self):
@@ -2820,27 +2820,27 @@ class PgnTestCase(unittest.TestCase):
 
     def test_annotations(self):
         game = chess.pgn.Game()
-        game.comment = "foo [%bar] baz"
+        game.comment = ["foo [%bar] baz"]
 
         self.assertTrue(game.clock() is None)
         clock = 12345
         game.set_clock(clock)
-        self.assertEqual(game.comment, "foo [%bar] baz [%clk 3:25:45]")
+        self.assertEqual(game.comment, ["foo [%bar] baz", "[%clk 3:25:45]"])
         self.assertEqual(game.clock(), clock)
 
         self.assertTrue(game.eval() is None)
         game.set_eval(chess.engine.PovScore(chess.engine.Cp(-80), chess.WHITE))
-        self.assertEqual(game.comment, "foo [%bar] baz [%clk 3:25:45] [%eval -0.80]")
+        self.assertEqual(game.comment, ["foo [%bar] baz", "[%clk 3:25:45]", "[%eval -0.80]"])
         self.assertEqual(game.eval().white().score(), -80)
         self.assertEqual(game.eval_depth(), None)
         game.set_eval(chess.engine.PovScore(chess.engine.Mate(1), chess.WHITE), 5)
-        self.assertEqual(game.comment, "foo [%bar] baz [%clk 3:25:45] [%eval #1,5]")
+        self.assertEqual(game.comment, ["foo [%bar] baz", "[%clk 3:25:45]", "[%eval #1,5]"])
         self.assertEqual(game.eval().white().mate(), 1)
         self.assertEqual(game.eval_depth(), 5)
 
         self.assertEqual(game.arrows(), [])
         game.set_arrows([(chess.A1, chess.A1), chess.svg.Arrow(chess.A1, chess.H1, color="red"), chess.svg.Arrow(chess.B1, chess.B8)])
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%eval #1,5]")
+        self.assertEqual(game.comment, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]", "[%eval #1,5]"])
         arrows = game.arrows()
         self.assertEqual(len(arrows), 3)
         self.assertEqual(arrows[0].color, "green")
@@ -2850,18 +2850,18 @@ class PgnTestCase(unittest.TestCase):
         self.assertTrue(game.emt() is None)
         emt = 321
         game.set_emt(emt)
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%eval #1,5] [%emt 0:05:21]")
+        self.assertEqual(game.comment, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]", "[%eval #1,5]", "[%emt 0:05:21]"])
         self.assertEqual(game.emt(), emt)
 
         game.set_eval(None)
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45] [%emt 0:05:21]")
+        self.assertEqual(game.comment, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]", "[%emt 0:05:21]"])
 
         game.set_emt(None)
-        self.assertEqual(game.comment, "[%csl Ga1][%cal Ra1h1,Gb1b8] foo [%bar] baz [%clk 3:25:45]")
+        self.assertEqual(game.comment, ["[%csl Ga1][%cal Ra1h1,Gb1b8]", "foo [%bar] baz", "[%clk 3:25:45]"])
 
         game.set_clock(None)
         game.set_arrows([])
-        self.assertEqual(game.comment, "foo [%bar] baz")
+        self.assertEqual(game.comment, ["foo [%bar] baz"])
 
     def test_eval(self):
         game = chess.pgn.Game()
@@ -2871,28 +2871,28 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_emt(self):
         game = chess.pgn.Game()
-        game.comment = "[%emt 0:00:01.234]"
+        game.comment = ["[%emt 0:00:01.234]"]
         self.assertEqual(game.emt(), 1.234)
 
         game.set_emt(6.54321)
-        self.assertEqual(game.comment, "[%emt 0:00:06.543]")
+        self.assertEqual(game.comment, ["[%emt 0:00:06.543]"])
         self.assertEqual(game.emt(), 6.543)
 
         game.set_emt(-70)
-        self.assertEqual(game.comment, "[%emt 0:00:00]")  # Clamped
+        self.assertEqual(game.comment, ["[%emt 0:00:00]"])  # Clamped
         self.assertEqual(game.emt(), 0)
 
     def test_float_clk(self):
         game = chess.pgn.Game()
-        game.comment = "[%clk 0:00:01.234]"
+        game.comment = ["[%clk 0:00:01.234]"]
         self.assertEqual(game.clock(), 1.234)
 
         game.set_clock(6.54321)
-        self.assertEqual(game.comment, "[%clk 0:00:06.543]")
+        self.assertEqual(game.comment, ["[%clk 0:00:06.543]"])
         self.assertEqual(game.clock(), 6.543)
 
         game.set_clock(-70)
-        self.assertEqual(game.comment, "[%clk 0:00:00]")  # Clamped
+        self.assertEqual(game.comment, ["[%clk 0:00:00]"])  # Clamped
         self.assertEqual(game.clock(), 0)
 
     def test_node_turn(self):

--- a/test.py
+++ b/test.py
@@ -2215,6 +2215,14 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(sixth_game.headers["White"], "Deep Blue (Computer)")
         self.assertEqual(sixth_game.headers["Result"], "1-0")
 
+    def test_read_game_with_multicomment_move(self):
+        pgn = io.StringIO("1. e4 {A common opening} 1... e5 {A common response} {An uncommon comment}")
+        game = chess.pgn.read_game(pgn)
+        first_move = game.variation(0)
+        self.assertEqual(first_move.comment, ["A common opening"])
+        second_move = first_move.variation(0)
+        self.assertEqual(second_move.comment, ["A common response", "An uncommon comment"])
+
     def test_comment_at_eol(self):
         pgn = io.StringIO(textwrap.dedent("""\
             1. e4 e5 2. Nf3 Nc6 3. Bc4 Bc5 4. c3 Nf6 5. d3 d6 6. Nbd2 a6 $6 (6... Bb6 $5 {

--- a/test.py
+++ b/test.py
@@ -2078,29 +2078,29 @@ class PgnTestCase(unittest.TestCase):
 
     def test_exporter(self):
         game = chess.pgn.Game()
-        game.comment.set("Test game:")
+        game.comment = "Test game:"
         game.headers["Result"] = "*"
         game.headers["VeryLongHeader"] = "This is a very long header, much wider than the 80 columns that PGNs are formatted with by default"
 
         e4 = game.add_variation(game.board().parse_san("e4"))
-        e4.comment.set("Scandinavian Defense:")
+        e4.comment = "Scandinavian Defense:"
 
         e4_d5 = e4.add_variation(e4.board().parse_san("d5"))
 
         e4_h5 = e4.add_variation(e4.board().parse_san("h5"))
         e4_h5.nags.add(chess.pgn.NAG_MISTAKE)
-        e4_h5.starting_comment.set("This")
-        e4_h5.comment.set("is nonsense")
+        e4_h5.starting_comment = "This"
+        e4_h5.comment = "is nonsense"
 
         e4_e5 = e4.add_variation(e4.board().parse_san("e5"))
         e4_e5_Qf3 = e4_e5.add_variation(e4_e5.board().parse_san("Qf3"))
         e4_e5_Qf3.nags.add(chess.pgn.NAG_MISTAKE)
 
         e4_c5 = e4.add_variation(e4.board().parse_san("c5"))
-        e4_c5.comment.set("Sicilian")
+        e4_c5.comment = "Sicilian"
 
         e4_d5_exd5 = e4_d5.add_main_variation(e4_d5.board().parse_san("exd5"))
-        e4_d5_exd5.comment.set(["Best", "and the end of this example"])
+        e4_d5_exd5.comment = ["Best", "and the end of this example"]
 
         # Test string exporter with various options.
         exporter = chess.pgn.StringExporter(headers=False, comments=False, variations=False)
@@ -2828,7 +2828,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_annotations(self):
         game = chess.pgn.Game()
-        game.comment.set("foo [%bar] baz")
+        game.comment = "foo [%bar] baz"
 
         self.assertTrue(game.clock() is None)
         clock = 12345
@@ -2879,7 +2879,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_emt(self):
         game = chess.pgn.Game()
-        game.comment.set("[%emt 0:00:01.234]")
+        game.comment = "[%emt 0:00:01.234]"
         self.assertEqual(game.emt(), 1.234)
 
         game.set_emt(6.54321)
@@ -2892,7 +2892,7 @@ class PgnTestCase(unittest.TestCase):
 
     def test_float_clk(self):
         game = chess.pgn.Game()
-        game.comment.set("[%clk 0:00:01.234]")
+        game.comment = "[%clk 0:00:01.234]"
         self.assertEqual(game.clock(), 1.234)
 
         game.set_clock(6.54321)


### PR DESCRIPTION
Some chess programs that write PGN files (including lichess.org and others mentioned in the linked issue) will write multiple consecutive braced comments--e.g., `1. e4 { A very common opening } { Perhaps too common ... } { [%clk 0:00:01] }`. Previously, when read by `chess.pgn.read_game()`, these comments would be joined into a single comment with a single space between them. This PR creates a new class to read, store, and write these comments while keeping them separate. The user interface is kept backwards compatible by using `@property` decorators to allow assignment and comparison of bare strings and string lists to game node comments.

Closes #946