### PR TITLE
1109-pylint-interventions

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -3402,7 +3402,7 @@ class Board(BaseBoard):
             if white_h_side and msb(white_h_side) < msb(white_king_mask):
                 white_h_side = 0
 
-            black_a_side = (black_castling & -black_castling)
+            black_a_side = black_castling & -black_castling
             black_h_side = BB_SQUARES[msb(black_castling)] if black_castling else BB_EMPTY
 
             if black_a_side and msb(black_a_side) > msb(black_king_mask):

--- a/release.py
+++ b/release.py
@@ -60,7 +60,8 @@ def tag_and_push():
         print(f">>> Creating {release_filename} ...")
         first_section = False
         prev_line = None
-        with open(release_filename, "w") as release_txt, open("CHANGELOG.rst", "r") as changelog_file:
+        with open(release_filename, "w") as release_txt,\
+                open("CHANGELOG.rst", "r") as changelog_file:
             headline = f"python-chess {tagname}"
             release_txt.write(headline + os.linesep)
 


### PR DESCRIPTION
This PR fixes two minor pylint alerts.
It makes a long line shorther and removes unneccesary parentheses.

More detials appear in the commit mesage of each interventions.