### PR TITLE
Fix error when parsing UCI options

### DIFF
--- a/.github/workflows/setup-ubuntu-latest.sh
+++ b/.github/workflows/setup-ubuntu-latest.sh
@@ -6,6 +6,9 @@ sudo apt-get install -y stockfish
 # Crafty
 sudo apt-get install -y crafty
 
+# Fairy-stockfish
+sudo apt-get install -y fairy-stockfish
+
 # Gaviota libgtb
 git clone https://github.com/michiguel/Gaviota-Tablebases.git --depth 1
 cd Gaviota-Tablebases

--- a/.github/workflows/setup-windows-latest.sh
+++ b/.github/workflows/setup-windows-latest.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-echo Download ...
+echo Download stockfish ...
 choco install wget
 wget https://github.com/official-stockfish/Stockfish/releases/download/sf_16/stockfish-windows-x86-64-avx2.zip
 
@@ -10,3 +10,7 @@ echo Unzip ..
 echo Setup path ...
 mv stockfish-windows-x86-64-avx2.exe stockfish.exe
 pwd >> $GITHUB_PATH
+
+echo Download fairy-stockfish ...
+wget https://github.com/fairy-stockfish/Fairy-Stockfish/releases/latest/download/fairy-stockfish-largeboard_x86-64.exe
+mv fairy-stockfish-largeboard_x86-64.exe fairy-stockfish.exe

--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1367,7 +1367,8 @@ class UciProtocol(Protocol):
                 var = []
 
                 parameters = list(option_parts.keys()) + ['var']
-                option_regex = fr"\s*({'|'.join(parameters)})\s*"
+                inner_regex = '|'.join([fr"\b{parameter}\b" for parameter in parameters])
+                option_regex = fr"\s*({inner_regex})\s*"
                 for token in re.split(option_regex, arg.strip()):
                     if token == "var" or (token in option_parts and not option_parts[token]):
                         current_parameter = token

--- a/test.py
+++ b/test.py
@@ -3147,6 +3147,21 @@ class EngineTestCase(unittest.TestCase):
         with chess.engine.SimpleEngine.popen_uci("fairy-stockfish", setpgrp=True, debug=True):
             pass
 
+    def test_uci_option_parse(self):
+        async def main():
+            protocol = chess.engine.UciProtocol()
+            mock = chess.engine.MockTransport(protocol)
+
+            mock.expect("uci", ["option name UCI_Variant type combo default chess var bughouse var chess var mini var minishogi var threekings", "uciok"])
+            await protocol.initialize()
+            mock.assert_done()
+
+            mock.expect("isready", ["readyok"])
+            await protocol.ping()
+            mock.assert_done()
+
+        asyncio.run(main())
+
     @catchAndSkip(FileNotFoundError, "need crafty")
     def test_crafty_play_to_mate(self):
         logging.disable(logging.WARNING)

--- a/test.py
+++ b/test.py
@@ -3142,6 +3142,11 @@ class EngineTestCase(unittest.TestCase):
         with self.assertRaises(chess.engine.EngineTerminatedError), engine:
             engine.ping()
 
+    @catchAndSkip(FileNotFoundError, "need fairy-stockfish")
+    def test_fairy_sf_initialize(self):
+        with chess.engine.SimpleEngine.popen_uci("fairy-stockfish", setpgrp=True, debug=True):
+            pass
+
     @catchAndSkip(FileNotFoundError, "need crafty")
     def test_crafty_play_to_mate(self):
         logging.disable(logging.WARNING)

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ passenv = LD_LIBRARY_PATH
 whitelist_externals =
     stockfish
     crafty
+    fairy-stockfish
 commands =
     python test.py --verbose
     python -m doctest README.rst --verbose


### PR DESCRIPTION
The regex that splits a UCI option into parts did not include word boundries, so words like "mini" would be split into "min" and "i", leading to parse errors. This commit puts word boundries into the regex to fix this.

Fixes #1112