### PR TITLE
Add 'movesleft' parameter to UCI info parsing

### DIFF
--- a/chess/engine.py
+++ b/chess/engine.py
@@ -1771,7 +1771,8 @@ def _parse_uci_info(arg: str, root_board: chess.Board, selector: Info = INFO_ALL
         if parameter == "string":
             info["string"] = remaining_line
             break
-        elif parameter in ["depth", "seldepth", "nodes", "multipv", "currmovenumber", "hashfull", "nps", "tbhits", "cpuload"]:
+        elif parameter in ["depth", "seldepth", "nodes", "multipv", "currmovenumber",
+                           "hashfull", "nps", "tbhits", "cpuload", "movesleft"]:
             try:
                 number, remaining_line = _next_token(remaining_line)
                 info[parameter] = int(number)  # type: ignore

--- a/test.py
+++ b/test.py
@@ -3508,14 +3508,15 @@ class EngineTestCase(unittest.TestCase):
         self.assertEqual(info["seldepth"], 8)
         self.assertEqual(info["score"], chess.engine.PovScore(chess.engine.Mate(+3), chess.WHITE))
 
-        # Info: tbhits, cpuload, hashfull, time, nodes, nps.
-        info = chess.engine._parse_uci_info("tbhits 123 cpuload 456 hashfull 789 time 987 nodes 654 nps 321", board)
+        # Info: tbhits, cpuload, hashfull, time, nodes, nps, movesleft.
+        info = chess.engine._parse_uci_info("tbhits 123 cpuload 456 hashfull 789 movesleft 42 time 987 nodes 654 nps 321", board)
         self.assertEqual(info["tbhits"], 123)
         self.assertEqual(info["cpuload"], 456)
         self.assertEqual(info["hashfull"], 789)
         self.assertEqual(info["time"], 0.987)
         self.assertEqual(info["nodes"], 654)
         self.assertEqual(info["nps"], 321)
+        self.assertEqual(info["movesleft"], 42)
 
         # Hakkapeliitta double spaces.
         info = chess.engine._parse_uci_info("depth 10 seldepth 9 score cp 22  time 17 nodes 48299 nps 2683000 tbhits 0", board)


### PR DESCRIPTION
Add `movesleft` to the list of recognized `info` values.

`movesleft` is a prediction of the remaining game duration in ply, it's is output by Leela Chess Zero (since 3 years ago already), and always had to patch the python-chess in order to get it (there's no way to get "unknown" fields even as a string).

I guess it makes sense to upstream it instead.