### PR TITLE
Multiple kings per color (was_into_check and more affected)

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -916,7 +916,7 @@ class BaseBoard:
         considered.
         """
         king_mask = self.occupied_co[color] & self.kings & ~self.promoted
-        return msb(king_mask) if king_mask and popcount(self.kings) == 1 else None
+        return msb(king_mask) if king_mask and popcount(king_mask) == 1 else None
 
     def attacks_mask(self, square: Square) -> Bitboard:
         bb_square = BB_SQUARES[square]

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -2005,7 +2005,7 @@ class Board(BaseBoard):
 
     def was_into_check(self) -> bool:
         king = self.king(not self.turn)
-        return king is not None and self.is_attacked_by(self.turn, king)
+        return popcount(self.kings) == 1 and king is not None and self.is_attacked_by(self.turn, king)
 
     def is_pseudo_legal(self, move: Move) -> bool:
         # Null moves are not pseudo-legal.

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -916,7 +916,7 @@ class BaseBoard:
         considered.
         """
         king_mask = self.occupied_co[color] & self.kings & ~self.promoted
-        return msb(king_mask) if king_mask else None
+        return msb(king_mask) if king_mask and popcount(self.kings) == 1 else None
 
     def attacks_mask(self, square: Square) -> Bitboard:
         bb_square = BB_SQUARES[square]
@@ -2005,7 +2005,7 @@ class Board(BaseBoard):
 
     def was_into_check(self) -> bool:
         king = self.king(not self.turn)
-        return popcount(self.kings) == 1 and king is not None and self.is_attacked_by(self.turn, king)
+        return king is not None and self.is_attacked_by(self.turn, king)
 
     def is_pseudo_legal(self, move: Move) -> bool:
         # Null moves are not pseudo-legal.

--- a/test.py
+++ b/test.py
@@ -1720,6 +1720,18 @@ class BoardTestCase(unittest.TestCase):
         self.assertFalse(board.has_legal_en_passant())
         self.assertEqual(len(list(board.legal_moves)), 2)
 
+    def test_multiple_kings(self):
+        board = chess.Board("KKKK1kkk/8/8/8/8/8/8/8 w - - 0 1")
+        self.assertEqual(board.king(chess.WHITE), None)
+
+        # https://github.com/niklasf/python-chess/issues/1169#issuecomment-3838025276
+        board = chess.Board(None)
+        board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
+        board.set_piece_at(chess.A8, chess.Piece(chess.KING, chess.BLACK)) # attacked
+        board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK)) # safe
+        board.turn = chess.WHITE
+        self.assertTrue(board.was_into_check())
+
 
 class LegalMoveGeneratorTestCase(unittest.TestCase):
 

--- a/test.py
+++ b/test.py
@@ -1724,14 +1724,6 @@ class BoardTestCase(unittest.TestCase):
         board = chess.Board("KKKK1kkk/8/8/8/8/8/8/8 w - - 0 1")
         self.assertEqual(board.king(chess.WHITE), None)
 
-        # https://github.com/niklasf/python-chess/issues/1169#issuecomment-3838025276
-        board = chess.Board(None)
-        board.set_piece_at(chess.A1, chess.Piece(chess.ROOK, chess.WHITE))
-        board.set_piece_at(chess.A8, chess.Piece(chess.KING, chess.BLACK)) # attacked
-        board.set_piece_at(chess.H8, chess.Piece(chess.KING, chess.BLACK)) # safe
-        board.turn = chess.WHITE
-        self.assertTrue(board.was_into_check())
-
 
 class LegalMoveGeneratorTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Not only of https://github.com/niklasf/python-chess/issues/1169 that `Board.king()` function is completely wrong for multiple kings per color but `msb(king)` or `lsb(king)` don't make sense if there's multiple kings for one color.