### PR TITLE
Avoid `Piece` creation in `BaseBoard.board_fen()` for 108% speedup

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1157,7 +1157,10 @@ class BaseBoard:
         # board bitboards and avoid allocating Piece objects per occupied square.
         # If piece_at() is overridden in a subclass, fall back to the original
         # behavior so custom piece lookup semantics are preserved.
-        if type(self).piece_at is BaseBoard.piece_at:
+        if (
+            type(self).piece_at is BaseBoard.piece_at and
+            type(self).piece_type_at is BaseBoard.piece_type_at
+        ):
             append = builder.append
             occupied = self.occupied
             occupied_white = self.occupied_co[WHITE]

--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -1146,6 +1146,65 @@ class BaseBoard:
         builder: List[str] = []
         empty = 0
 
+        if promoted is None:
+            promoted_mask = self._effective_promoted()
+        elif promoted:
+            promoted_mask = self.promoted
+        else:
+            promoted_mask = BB_EMPTY
+
+        # Fast path for the standard implementation: read directly from the
+        # board bitboards and avoid allocating Piece objects per occupied square.
+        # If piece_at() is overridden in a subclass, fall back to the original
+        # behavior so custom piece lookup semantics are preserved.
+        if type(self).piece_at is BaseBoard.piece_at:
+            append = builder.append
+            occupied = self.occupied
+            occupied_white = self.occupied_co[WHITE]
+            pawns = self.pawns
+            knights = self.knights
+            bishops = self.bishops
+            rooks = self.rooks
+            queens = self.queens
+
+            for square in SQUARES_180:
+                mask = BB_SQUARES[square]
+
+                if not occupied & mask:
+                    empty += 1
+                else:
+                    if empty:
+                        append(str(empty))
+                        empty = 0
+
+                    color_is_white = bool(occupied_white & mask)
+
+                    if pawns & mask:
+                        append("P" if color_is_white else "p")
+                    elif knights & mask:
+                        append("N" if color_is_white else "n")
+                    elif bishops & mask:
+                        append("B" if color_is_white else "b")
+                    elif rooks & mask:
+                        append("R" if color_is_white else "r")
+                    elif queens & mask:
+                        append("Q" if color_is_white else "q")
+                    else:
+                        append("K" if color_is_white else "k")
+
+                    if mask & promoted_mask:
+                        append("~")
+
+                if mask & BB_FILE_H:
+                    if empty:
+                        append(str(empty))
+                        empty = 0
+
+                    if square != H1:
+                        append("/")
+
+            return "".join(builder)
+
         for square in SQUARES_180:
             piece = self.piece_at(square)
 
@@ -1157,12 +1216,6 @@ class BaseBoard:
                     empty = 0
                 builder.append(piece.symbol())
 
-                if promoted is None:
-                    promoted_mask = self._effective_promoted()
-                elif promoted:
-                    promoted_mask = self.promoted
-                else:
-                    promoted_mask = BB_EMPTY
                 if BB_SQUARES[square] & promoted_mask:
                     builder.append("~")
 

--- a/test.py
+++ b/test.py
@@ -1784,6 +1784,15 @@ class BaseBoardTestCase(unittest.TestCase):
 
         self.assertEqual(OverrideBoard.empty().board_fen(), "8/8/8/8/4K3/8/8/8")
 
+    def test_board_fen_respects_piece_type_at_override(self):
+        class OverrideBoard(chess.BaseBoard):
+            def piece_type_at(self, square):
+                if square == chess.E4:
+                    return chess.KING
+                return None
+
+        self.assertEqual(OverrideBoard.empty().board_fen(), "8/8/8/8/4k3/8/8/8")
+
 
 class SquareSetTestCase(unittest.TestCase):
 

--- a/test.py
+++ b/test.py
@@ -1775,6 +1775,15 @@ class BaseBoardTestCase(unittest.TestCase):
         a.set_piece_map({})
         self.assertNotEqual(a, b)
 
+    def test_board_fen_respects_piece_at_override(self):
+        class OverrideBoard(chess.BaseBoard):
+            def piece_at(self, square):
+                if square == chess.E4:
+                    return chess.Piece(chess.KING, chess.WHITE)
+                return None
+
+        self.assertEqual(OverrideBoard.empty().board_fen(), "8/8/8/8/4K3/8/8/8")
+
 
 class SquareSetTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Currently `BaseBoard.board_fen()` calls `self.piece_at()` for each square while building the board FEN, which creates a `Piece` object only to get its `piece.symbol()`. I've identified that ephemeral object creation as a major speed bottleneck in some code I'm writing for [Hyperchess](https://hyperchess.ai) to extract all unique FENs from the Lichess open database.

This PR adds a block which skips the intermediate `Piece` creation and sets the piece symbol manually by checking the square's piece with fast checks against `self`'s bitboards (`.pawns`, `.knights`, etc.), after checking that neither `piece_at` nor `piece_type_at` have been overridden on the board instance (e.g. the change should not skip the existing path that relies on those methods if `self` is some `MyCustomBoard` that inherits from `Board`/`BaseBoard` and defines its own `piece_at`/`piece_type_at`).

Also moves this block up to get the promoted-piece mask once per call instead of once per occupied square:

```python
                if promoted is None:
                    promoted_mask = self._effective_promoted()
                elif promoted:
                    promoted_mask = self.promoted
                else:
                    promoted_mask = BB_EMPTY
```

Disclaimer: code was written with AI and after review I agree it's sound.

## Benchmark

This script records time spent inside `board.board_fen()` and was used to generate the before/after table below:

```python
import time

import chess
import chess.pgn

PATH_TO_PGN = "/path/to/file.pgn"
# https://database.lichess.org/standard/lichess_db_standard_rated_2026-02.pgn.zst
# PATH_TO_PGN = "lichess_db_standard_rated_2013-01.pgn"
MAX_GAMES = 5000

games = []
with open(PATH_TO_PGN, "r") as f:
    while len(games) < MAX_GAMES:
        game = chess.pgn.read_game(f)
        if game is None:
            break
        games.append(game)

num_positions = 0
total_elapsed = 0
for game in games:
    board = game.board()
    for move in game.mainline_moves():
        board.push(move)

        t0 = time.perf_counter()
        board.board_fen()
        total_elapsed += time.perf_counter() - t0

        num_positions += 1

calls_per_s = num_positions / total_elapsed

print(f"games={len(games)} num_positions={num_positions}")
print(f"total_elapsed={total_elapsed:.3f}")
print(f"calls_per_s={calls_per_s:.2f}")
```

| Metric | Before | After | Change |
|---|---:|---:|---:|
| `total_elapsed` | 6.888s | 3.298s | -52.1% |
| `calls_per_s` | 47314.46 | 98802.75 | +108.8% |