### PR TITLE
pgn: accept tag pairs with leading whitespace (fixes #1115)

### DIFF
--- a/chess/pgn.py
+++ b/chess/pgn.py
@@ -1636,13 +1636,14 @@ def read_game(handle: TextIO, *, Visitor: Any = GameBuilder) -> Any:
                 if not isinstance(managed_headers, Headers):
                     unmanaged_headers = Headers({})
 
-        if not line.startswith("["):
+        stripped = line.lstrip()
+        if not stripped.startswith("["):
             break
 
         consecutive_empty_lines = 0
 
         if not skipping_game:
-            tag_match = TAG_REGEX.match(line)
+            tag_match = TAG_REGEX.match(stripped)
             if tag_match:
                 visitor.visit_header(tag_match.group(1), tag_match.group(2))
                 if unmanaged_headers is not None:

--- a/test.py
+++ b/test.py
@@ -2233,6 +2233,24 @@ class PgnTestCase(unittest.TestCase):
         self.assertEqual(sixth_game.headers["White"], "Deep Blue (Computer)")
         self.assertEqual(sixth_game.headers["Result"], "1-0")
 
+    def test_read_game_with_leading_whitespace_before_header(self):
+        pgn = io.StringIO(
+            ' [Event "TCEC Season 27 - Entrance League"]\n'
+            '[Site "https://tcec-chess.com"]\n'
+            '[White "Patricia 3.1_dev_ca7ef0a3"]\n'
+            '[Black "Weiss 2.1-dev11"]\n'
+            '[Result "*"]\n'
+            "\n"
+            "1. d4 *"
+        )
+
+        game = chess.pgn.read_game(pgn)
+
+        self.assertEqual(game.headers["Event"], "TCEC Season 27 - Entrance League")
+        self.assertEqual(game.headers["White"], "Patricia 3.1_dev_ca7ef0a3")
+        self.assertEqual(game.next().move, chess.Move.from_uci("d2d4"))
+        self.assertEqual(game.errors, [])
+
     def test_read_game_with_multicomment_move(self):
         pgn = io.StringIO("1. e4 {A common opening} 1... e5 {A common response} {An uncommon comment}")
         game = chess.pgn.read_game(pgn)


### PR DESCRIPTION
## Summary

`read_game()` (and therefore `read_headers()`) failed to parse game
headers that are preceded by horizontal whitespace, e.g. a PGN string
that begins with `" [Event ...]"`.

The PGN standard (section 2.1) specifies that white space is not
significant, so a tag pair indented with spaces or tabs should be
accepted.

### Root cause

Two checks in the header-parsing loop used the raw `line` string:

1. `if not line.startswith("["):` — breaks out of the header loop for any
   line that doesn't begin **immediately** with `[`.
2. `TAG_REGEX.match(line)` — the regex is anchored at `^` and will not
   match a line with leading whitespace.

Together these caused the parser to treat an indented first tag as the
start of the movetext section, so no headers were ever parsed and the
game was returned with default header values.

### Fix

Strip leading whitespace into a local `stripped` variable before the
`startswith` guard and the regex match.  The original `line` value is
preserved for the movetext tokeniser that runs after the header loop.

### Reproducer (from #1115)

```python
import chess.pgn, io

pgn = io.StringIO(' [Event "Test"]\n[White "Alice"]\n[Black "Bob"]\n[Result "*"]\n\n1. e4 e5 *')
game = chess.pgn.read_game(pgn)
assert game.headers["Event"] == "Test"   # previously returned "?"
assert game.headers["White"] == "Alice"  # previously returned "?"
```

This pull request was prepared with the assistance of AI, under my direction and review.