### PR TITLE
Remove Test workflow badge from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,7 @@
 python-chess: a chess library for Python
 ========================================
 
-.. image:: https://github.com/niklasf/python-chess/workflows/Test/badge.svg
-    :target: https://github.com/niklasf/python-chess/actions
-    :alt: Test status
+
 
 .. image:: https://badge.fury.io/py/chess.svg
     :target: https://pypi.python.org/pypi/chess


### PR DESCRIPTION
Removes the Test workflow status badge from the README, as suggested by @niklasf in #1196.
The badge used the legacy https://github.com/niklasf/python-chess/workflows/Test/badge.svg format, which is not scoped to a branch or event and so reflected the latest run across all branches including pull_request runs. That is why it could show red while push runs on the default branch were green. Rather than re-scope the URL, this drops the badge entirely, since the Actions tab and per-commit status checks already surface CI state.
No other badges are affected.
Closes #1196