### PR TITLE
Fix `parse_rank()`, `rank_name()`

### DIFF
--- a/chess/__init__.py
+++ b/chess/__init__.py
@@ -288,18 +288,18 @@ def file_name(file: File) -> str:
     """Gets the name of the file, like ``a``."""
     return FILE_NAMES[file]
 
-def parse_rank(name: str) -> File:
+def parse_rank(name: str) -> Rank:
     """
     Gets the rank index for the given rank *name*
     (e.g., ``1`` returns ``0``).
 
     :raises: :exc:`ValueError` if the rank name is invalid.
     """
-    return FILE_NAMES.index(name)
+    return RANK_NAMES.index(name)
 
 def rank_name(rank: Rank) -> str:
     """Gets the name of the rank, like ``1``."""
-    return FILE_NAMES[rank]
+    return RANK_NAMES[rank]
 
 def square_file(square: Square) -> File:
     """Gets the file index of the square where ``0`` is the a-file."""

--- a/test.py
+++ b/test.py
@@ -77,6 +77,50 @@ class SquareTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.assertEqual(chess.parse_square("a0"))
 
+    def test_parse_file(self):
+        self.assertEqual(chess.parse_file("a"), 0)
+        self.assertEqual(chess.parse_file("b"), 1)
+        self.assertEqual(chess.parse_file("c"), 2)
+        self.assertEqual(chess.parse_file("d"), 3)
+        self.assertEqual(chess.parse_file("e"), 4)
+        self.assertEqual(chess.parse_file("f"), 5)
+        self.assertEqual(chess.parse_file("g"), 6)
+        self.assertEqual(chess.parse_file("h"), 7)
+        with self.assertRaises(ValueError):
+            chess.parse_file("A")
+
+    def test_file_name(self):
+        self.assertEqual(chess.file_name(0), "a")
+        self.assertEqual(chess.file_name(1), "b")
+        self.assertEqual(chess.file_name(2), "c")
+        self.assertEqual(chess.file_name(3), "d")
+        self.assertEqual(chess.file_name(4), "e")
+        self.assertEqual(chess.file_name(5), "f")
+        self.assertEqual(chess.file_name(6), "g")
+        self.assertEqual(chess.file_name(7), "h")
+
+    def test_parse_rank(self):
+        self.assertEqual(chess.parse_rank("1"), 0)
+        self.assertEqual(chess.parse_rank("2"), 1)
+        self.assertEqual(chess.parse_rank("3"), 2)
+        self.assertEqual(chess.parse_rank("4"), 3)
+        self.assertEqual(chess.parse_rank("5"), 4)
+        self.assertEqual(chess.parse_rank("6"), 5)
+        self.assertEqual(chess.parse_rank("7"), 6)
+        self.assertEqual(chess.parse_rank("8"), 7)
+        with self.assertRaises(ValueError):
+            chess.parse_rank("0")
+
+    def test_rank_name(self):
+        self.assertEqual(chess.rank_name(0), "1")
+        self.assertEqual(chess.rank_name(1), "2")
+        self.assertEqual(chess.rank_name(2), "3")
+        self.assertEqual(chess.rank_name(3), "4")
+        self.assertEqual(chess.rank_name(4), "5")
+        self.assertEqual(chess.rank_name(5), "6")
+        self.assertEqual(chess.rank_name(6), "7")
+        self.assertEqual(chess.rank_name(7), "8")
+
     def test_square_distance(self):
         self.assertEqual(chess.square_distance(chess.A1, chess.A1), 0)
         self.assertEqual(chess.square_distance(chess.A1, chess.H8), 7)


### PR DESCRIPTION
I apparently committed this bug 11 months ago in https://github.com/niklasf/python-chess/pull/1163. Codex [found it](https://github.com/jacksonthall22/chess.ts/pull/24) while helping me build `chess.ts`, a transpilation of `python-chess` to typescript. I basically instruct it to go commit by commit and reproduce the diffs as faithfully as possible, notwithstanding syntax and a few language-specific patterns for which I document explicit instructions/conventions for how to transpile - but it's not supposed to make any decisions or changes, even if the python is wrong, unoptimized, etc. It initially, correctly, coded the bug into the typescript and left me a TODO to fix when it's patched in `python-chess`. Funny that otherwise I would have never noticed this 😛